### PR TITLE
[#7] cookbook now works again when not installing separate java 

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,6 +53,14 @@ platforms:
     require_chef_omnibus: latest
 
 suites:
+- name: confluence-installer-mysql-no-java
+  run_list:
+  - recipe[confluence]
+  attributes:
+    mysql:
+      server_root_password: iloverandompasswordsbutthiswilldo
+      server_repl_password: iloverandompasswordsbutthiswilldo
+      server_debian_password: iloverandompasswordsbutthiswilldo
 - name: confluence-installer-mysql
   run_list:
   - recipe[java]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,12 @@ default['confluence']['url_base']       = 'http://www.atlassian.com/software/con
 default['confluence']['user']           = 'confluence'
 default['confluence']['version']        = '5.3'
 
+if node['java'] && node['java']['java_home']
+  default['confluence']['jre_home'] = "#{node['java']['java_home']}/jre/"
+else
+  default['confluence']['jre_home'] = "#{node['confluence']['install_path']}/jre/"
+end
+
 if node['kernel']['machine'] == 'x86_64'
   default['confluence']['arch'] = 'x64'
 else

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -41,7 +41,7 @@ end
 
 execute 'Generating Self-Signed Java Keystore' do
   command <<-COMMAND
-    #{node['java']['java_home']}/bin/keytool -genkey \
+    #{node['confluence']['jre_home']}/bin/keytool -genkey \
       -alias #{settings['tomcat']['keyAlias']} \
       -keyalg RSA \
       -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -38,7 +38,7 @@ end
 
 execute 'Generating Self-Signed Java Keystore' do
   command <<-COMMAND
-    #{node['java']['java_home']}/bin/keytool -genkey \
+    #{node['confluence']['jre_home']}/bin/keytool -genkey \
       -alias #{settings['tomcat']['keyAlias']} \
       -keyalg RSA \
       -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \

--- a/templates/default/confluence.init.erb
+++ b/templates/default/confluence.init.erb
@@ -65,7 +65,7 @@ case "$1" in
     <% when 'rhel' -%>
     status -p $BASE/work/catalina.pid $APP
     <% else -%>
-    status_of_proc -p $BASE/work/catalina.pid $JAVA_HOME/bin/java $APP
+    status_of_proc -p $BASE/work/catalina.pid <%= node['confluence']['jre_home'] %>bin/java $APP
     <% end -%>
     RETVAL=$?
     ;;

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -41,8 +41,4 @@ cd $PUSHED_DIR
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
 
-<% if node['java'] && node['java']['java_home'] -%>
-JRE_HOME="<%= node['java']['java_home'] %>/jre/"; export JRE_HOME
-<% else -%>
-JRE_HOME="<%= node['confluence']['install_path'] %>/jre/"; export JRE_HOME
-<% end -%>
+JRE_HOME="<%= node['confluence']['jre_home'] %>"; export JRE_HOME


### PR DESCRIPTION
- Created a new suite called `confluence-installer-mysql-no-java` that reproduces #7.
- Created a new attribute `node['confluence']['jre_home']` (not sure yet how to document this).
- It seemed logical to make the changes to `templates/default/confluence.init.erb` although it seems that `status_of_proc` accepts **any** argument in place of `$JAVA_HOME/bin/java` and would still work... I even tried `bin/java`, which makes no sens, and it still returns the correct answer (service running or not).
- Tested with mysql on:
  - centos-5
  - centos-6
  - debian-7
  - ubuntu-1204
  - ubuntu-1210
  - ubuntu-1304
  - ubuntu-1310
- Could not test on fedora flavors as test-kitchen crashes when trying to install mysql.
