### PR TITLE
Merge "settings" hashes from attribute and data bag.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -224,7 +224,6 @@ end
 default['confluence']['database']['host']     = 'localhost'
 default['confluence']['database']['name']     = 'confluence'
 default['confluence']['database']['password'] = 'changeit'
-default['confluence']['database']['port']     = 3306
 default['confluence']['database']['type']     = 'mysql'
 default['confluence']['database']['user']     = 'confluence'
 

--- a/libraries/confluence.rb
+++ b/libraries/confluence.rb
@@ -27,19 +27,20 @@ class Chef
         begin
           if Chef::Config[:solo]
             begin
-              settings = Chef::DataBagItem.load('confluence', 'confluence')['local']
+              databag_item = Chef::DataBagItem.load('confluence', 'confluence')['local']
             rescue
               Chef::Log.info('No confluence data bag found')
             end
           else
             begin
-              settings = Chef::EncryptedDataBagItem.load('confluence', 'confluence')[node.chef_environment]
+              databag_item = Chef::EncryptedDataBagItem.load('confluence', 'confluence')[node.chef_environment]
             rescue
               Chef::Log.info('No confluence encrypted data bag found')
             end
           end
         ensure
-          settings ||= node['confluence']
+          databag_item ||= {}
+          settings = Chef::Mixin::DeepMerge.deep_merge(databag_item, node['confluence'].to_hash)
 
           case settings['database']['type']
           when 'mysql'


### PR DESCRIPTION
The similar changes for Stash cookbook: https://github.com/bflad/chef-stash/pull/44
##### 1. Default settings should not be specified in attribute files

`Chef::Recipe::Confluence.settings` method is going to set default settings:

``` ruby
settings ||= node['confluence']
...
case settings['database']['type']
when 'mysql'
  settings['database']['port'] ||= 3306
when 'postgresql'
  settings['database']['port'] ||= 5432
...
```

But it will never be done because the node will always have these attributes specified in `attributes/default.rb`. 
For example, even if we set `['database']['type'] = 'postgresql'`, the port will be "3306" anyway. So that, these attributes should not be specified in attribute file.
##### 2. `settings` should be a hash.

While copying `settings ||= node['confluence']` it should be also converted to the Hash object, because the Node object is read-only and overriding below will be unavailable. 
