### PR TITLE
Fix TravisCI build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 1.9.3
+  - 2.2.0
 before_script:
   - bundle exec berks install
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 group :test do
   gem 'chefspec', '~> 4.0'
   gem 'foodcritic', '~> 3.0.3'
-  gem 'rubocop', '~> 0.23'
+  gem 'rubocop', '~> 0.32'
 end
 
 group :integration do

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,6 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-# rubocop:disable RegexpLiteral
 guard 'kitchen' do
   watch(%r{test/.+})
   watch(%r{^recipes/(.+)\.rb$})
@@ -11,4 +10,3 @@ guard 'kitchen' do
   watch(%r{^providers/(.+)\.rb})
   watch(%r{^resources/(.+)\.rb})
 end
-# rubocop:enable RegexpLiteral

--- a/files/default/tests/minitest/configuration_test.rb
+++ b/files/default/tests/minitest/configuration_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::configuration' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/database_test.rb
+++ b/files/default/tests/minitest/database_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::database' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::default' do
   include Helpers::Confluence
 
   # check other recipe tests
-
 end

--- a/files/default/tests/minitest/linux_cluster-standalone_test.rb
+++ b/files/default/tests/minitest/linux_cluster-standalone_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::linux_cluster-standalone' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/linux_cluster-war_test.rb
+++ b/files/default/tests/minitest/linux_cluster-war_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::linux_cluster-war' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/linux_installer_test.rb
+++ b/files/default/tests/minitest/linux_installer_test.rb
@@ -14,5 +14,4 @@ describe_recipe 'confluence::linux_installer' do
   it 'enables Confluence' do
     service('confluence').must_be_enabled
   end
-
 end

--- a/files/default/tests/minitest/linux_standalone_test.rb
+++ b/files/default/tests/minitest/linux_standalone_test.rb
@@ -14,5 +14,4 @@ describe_recipe 'confluence::linux_standalone' do
   it 'enables Confluence' do
     service('confluence').must_be_enabled
   end
-
 end

--- a/files/default/tests/minitest/linux_war_test.rb
+++ b/files/default/tests/minitest/linux_war_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::linux_war' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/windows_cluster-standalone_test.rb
+++ b/files/default/tests/minitest/windows_cluster-standalone_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::windows_cluster-standalone' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/windows_cluster-war_test.rb
+++ b/files/default/tests/minitest/windows_cluster-war_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::windows_cluster-war' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/windows_installer_test.rb
+++ b/files/default/tests/minitest/windows_installer_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::windows_installer' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/windows_standalone_test.rb
+++ b/files/default/tests/minitest/windows_standalone_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::windows_standalone' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/files/default/tests/minitest/windows_war_test.rb
+++ b/files/default/tests/minitest/windows_war_test.rb
@@ -4,5 +4,4 @@ describe_recipe 'confluence::windows_war' do
   include Helpers::Confluence
 
   # do work, son.
-
 end

--- a/libraries/confluence.rb
+++ b/libraries/confluence.rb
@@ -23,6 +23,7 @@ class Chef
   class Recipe
     # Chef::Recipe::Confluence class
     class Confluence
+      # rubocop:disable Metrics/AbcSize
       def self.settings(node)
         begin
           if Chef::Config[:solo]
@@ -54,6 +55,7 @@ class Chef
 
         settings
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end


### PR DESCRIPTION
- Use Ruby 2.2.0 for TravisCI
