### PR TITLE
Use Java bundled with installer for "installer" type

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,6 @@ provisioner:
 suites:
 - name: confluence-installer-mysql
   run_list:
-  - recipe[java]
   - recipe[confluence]
   attributes:
     mysql:
@@ -41,7 +40,6 @@ suites:
       server_debian_password: iloverandompasswordsbutthiswilldo
 - name: confluence-installer-postgresql
   run_list:
-  - recipe[java]
   - recipe[confluence]
   attributes:
     confluence:

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Suggested [Opscode Cookbooks](https://github.com/opscode-cookbooks/)
 
 ### JDK/JRE
 
-The Atlassian Confluence Linux installer will automatically configure a bundled JRE. If you wish to use your own JDK/JRE, with say the `java` cookbook, then as of this writing it must be Oracle JDK 7 ([Supported Platforms](https://confluence.atlassian.com/display/DOC/Supported+Platforms))
+The Atlassian Confluence Linux installer will automatically configure a bundled JRE.
 
-Necessary configuration with `java` cookbook:
-* `node['java']['install_flavor'] = "oracle"`
-* `node['java']['jdk_version'] = "7"`
-* `node['java']['oracle']['accept_oracle_download_terms'] = true`
+If you prefer Confluence stadalone installation, then you have to manage JDK/JRE 8
+([Supported Platforms](https://confluence.atlassian.com/display/DOC/Supported+Platforms))
+on this node. It can be done with `java` cookbook and appropricate attributes:
+
+* `node['java']['jdk_version'] = "8"`
 * `recipe[java]`
 
 ## Attributes

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,14 +35,6 @@ Vagrant.configure('2') do |config|
   config.vm.provision :chef_zero do |chef|
     chef.log_level = :debug
     chef.json = {
-      'java' => {
-        'install_flavor' => 'oracle',
-        'java_home' => '/usr/lib/jvm/java-7-oracle',
-        'jdk_version' => '7',
-        'oracle' => {
-          'accept_oracle_download_terms' => true
-        }
-      },
       'mysql' => {
         'server_root_password' => 'iloverandompasswordsbutthiswilldo',
         'server_repl_password' => 'iloverandompasswordsbutthiswilldo',

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -41,7 +41,7 @@ end
 
 execute 'Generating Self-Signed Java Keystore' do
   command <<-COMMAND
-    #{node['java']['java_home']}/bin/keytool -genkey \
+    #{node['confluence']['install_path']}/jre/bin/keytool -genkey \
       -alias #{settings['tomcat']['keyAlias']} \
       -keyalg RSA \
       -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \
@@ -68,5 +68,4 @@ end
 service 'confluence' do
   supports :status => true, :restart => true
   action :enable
-  subscribes :restart, 'java_ark[jdk]'
 end

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -41,8 +41,8 @@ cd $PUSHED_DIR
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
 
-<% if node['java'] && node['java']['java_home'] -%>
-JRE_HOME="<%= node['java']['java_home'] %>/jre/"; export JRE_HOME
-<% else -%>
+<% if node['confluence']['install_type'] == 'installer' -%>
 JRE_HOME="<%= node['confluence']['install_path'] %>/jre/"; export JRE_HOME
+<% else -%>
+JRE_HOME="<%= node['java']['java_home'] %>/jre/"; export JRE_HOME
 <% end -%>


### PR DESCRIPTION
This PR forces to use Java bundled with Confluence automated installer if `['confluence']['install_type'] == 'installer'`

If we use the automated installer, the required Java files are bundled and will be automatically put in place, so there is no reason to manage java on the side.

The only one case you need to manage JRE/JDK separately is the standalone installation. `java` cookbook can help with that. 
BTW, the required Java version is 8 for now (Confluence 5.8.*), so it is mentioned in the README.md

This changeset could break the backward compatibility in case you use a custom JRE/JDK for the Confluence instance. Thats why I suggest to release it with the major version bumped (v2.0.0).

cc:\ @bflad @esciara @racktear @kasen

UPDATE: It fixes GH-7
