### PR TITLE
Update Confluence automatically using the installer

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,6 +18,24 @@
 module Confluence
   # Confluence::Helpers module
   module Helpers
+    # Detects current Confluence version.
+    # Returns nil if Confluence isn't installed.
+    #
+    # @return [String] Confluence version
+    def confluence_version
+      pom_file = File.join(
+        node['confluence']['install_path'],
+        '/confluence/META-INF/maven/com.atlassian.confluence/confluence-webapp/pom.properties'
+      )
+
+      begin
+        return Regexp.last_match(1) if File.read(pom_file) =~ /^version=(.*)$/
+      rescue Errno::ENOENT
+        # Confluence is not installed
+        return nil
+      end
+    end
+
     # Merges Confluence settings from data bag and node attributes.
     # Data dag settings always has a higher priority.
     #

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -26,17 +26,19 @@ template "#{Chef::Config[:file_cache_path]}/atlassian-confluence-response.varfil
   mode '0644'
 end
 
-remote_file "#{Chef::Config[:file_cache_path]}/atlassian-confluence-#{node['confluence']['version']}-#{node['confluence']['arch']}.bin" do
-  source node['confluence']['url']
-  checksum node['confluence']['checksum']
-  mode '0755'
-  action :create_if_missing
-end
+# Install or upgrade confluence
+if confluence_version != node['confluence']['version']
+  remote_file "#{Chef::Config[:file_cache_path]}/atlassian-confluence-#{node['confluence']['version']}-#{node['confluence']['arch']}.bin" do
+    source node['confluence']['url']
+    checksum node['confluence']['checksum']
+    mode '0755'
+    action :create_if_missing
+  end
 
-execute "Installing Confluence #{node['confluence']['version']}" do
-  cwd Chef::Config[:file_cache_path]
-  command "./atlassian-confluence-#{node['confluence']['version']}-#{node['confluence']['arch']}.bin -q -varfile atlassian-confluence-response.varfile"
-  creates node['confluence']['install_path']
+  execute "Installing Confluence #{node['confluence']['version']}" do
+    cwd Chef::Config[:file_cache_path]
+    command "./atlassian-confluence-#{node['confluence']['version']}-#{node['confluence']['arch']}.bin -q -varfile atlassian-confluence-response.varfile"
+  end
 end
 
 execute 'Generating Self-Signed Java Keystore' do

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -32,7 +32,7 @@ if confluence_version != node['confluence']['version']
     source node['confluence']['url']
     checksum node['confluence']['checksum']
     mode '0755'
-    action :create_if_missing
+    action :create
   end
 
   execute "Installing Confluence #{node['confluence']['version']}" do

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -55,7 +55,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/atlassian-confluence-#{node['conf
   source node['confluence']['url']
   checksum node['confluence']['checksum']
   mode '0644'
-  action :create_if_missing
+  action :create
 end
 
 directory File.dirname(node['confluence']['install_path']) do

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -5,7 +5,7 @@
 rmiPort$Long=8000
 app.install.service$Boolean=true
 existingInstallationDir=<%= node['confluence']['install_path'] %>
-sys.confirmedUpdateInstallationString=<%= node['confluence']['update'] ? "true" : "false" %>
+sys.confirmedUpdateInstallationString=true
 sys.languageId=en
 sys.installationDir=<%= node['confluence']['install_path'] %>
 app.confHome=<%= node['confluence']['home_path'] %>


### PR DESCRIPTION
This PR makes `linux_installer` recipe to upgrade an existing Confluence instance if its version deffers  from `['confluence']['version']` attribute value.

Proposals:
- Confluence automated installer supports an unattended upgrade of existing Confluence installation. It works fine and could be very useful for cookbook users.
- It is still easy to control this behavior. Since it compares the value of `['confluence']['version']` attribute, it will not upgrade your existing Confluence installation unless you set (or override) this attribute value.
- This is a common behavior of the most of Chef application cookbooks. If we have new version set in the attribute, the cookbook should bring the node to the desired state.

Anyway, this PR changes the default behavior of the recipe, so I suggest to release it with the major version bumped (v2.0.0).

cc:\ @bflad @esciara @racktear @kasen
