### PR TITLE
Apache 2.4 support

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -19,8 +19,12 @@
 	LogLevel warn
 
 	<Proxy *>
+	<% if node['apache']['version'].to_f < 2.4 -%>
 		Order Deny,Allow
 		Allow from all
+	<% else -%>
+		Require all granted
+	<% end -%>
 	</Proxy>
 	ProxyPass        / http://localhost:<%= node['confluence']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
 	ProxyPassReverse / http://localhost:<%= node['confluence']['tomcat']['port'] %>/
@@ -43,8 +47,12 @@
 	LogLevel warn
 
 	<Proxy *>
+	<% if node['apache']['version'].to_f < 2.4 -%>
 		Order Deny,Allow
 		Allow from all
+	<% else -%>
+		Require all granted
+	<% end -%>
 	</Proxy>
 	ProxyPass        / http://localhost:<%= node['confluence']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
 	ProxyPassReverse / http://localhost:<%= node['confluence']['tomcat']['port'] %>/


### PR DESCRIPTION
The proxy syntax for apache 2.4 differs from 2.2. This will allow the cookbook to work across more platforms, for which 2.4 is sometimes the default.
