### PR TITLE
Use symlink for constant install path with multiple versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Removed references to unused `confluence.cfg.xml`.
   [[GH-41]](https://github.com/bflad/chef-confluence/issues/41)
+* Implemented ark cookbook with install directory versioning.
+  [[GH-40]](https://github.com/bflad/chef-confluence/issues/40)
 
 ## 1.7.1
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,6 +20,7 @@ supports 'scientific'
 supports 'ubuntu'
 
 depends 'apache2'
+depends 'ark'
 depends 'database', '~> 2.3'
 depends 'mysql', '~> 5.0'
 depends 'mysql_connector'

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -51,29 +51,14 @@ execute 'Generating Self-Signed Java Keystore' do
   only_if { settings['tomcat']['keystoreFile'] == "#{node['confluence']['home_path']}/.keystore" }
 end
 
-remote_file "#{Chef::Config[:file_cache_path]}/atlassian-confluence-#{node['confluence']['version']}.tar.gz" do
-  source node['confluence']['url']
+ark 'confluence' do
+  url node['confluence']['url']
+  prefix_root File.dirname(node['confluence']['install_path'])
+  home_dir node['confluence']['install_path']
   checksum node['confluence']['checksum']
-  mode '0644'
-  action :create
-end
-
-directory File.dirname(node['confluence']['install_path']) do
+  version node['confluence']['version']
   owner node['confluence']['user']
   group node['confluence']['user']
-  mode 00755
-  action :create
-  recursive true
-end
-
-execute "Extracting Confluence #{node['confluence']['version']}" do
-  cwd Chef::Config[:file_cache_path]
-  command <<-COMMAND
-    tar -zxf atlassian-confluence-#{node['confluence']['version']}.tar.gz
-    mv atlassian-confluence-#{node['confluence']['version']} #{node['confluence']['install_path']}
-    chown -R #{node['confluence']['user']} #{node['confluence']['install_path']}
-  COMMAND
-  creates "#{node['confluence']['install_path']}/confluence"
 end
 
 if settings['database']['type'] == 'mysql'


### PR DESCRIPTION
Seems this would be a bit more intuitive and similar to how capistrano and lots of other tools manage deployment of multiple versions. Any objections in principle?

```
opt
└── atlassian
    └── confluence
        ├── atlassian-confluence-5.4.5
        ├── atlassian-confluence-5.5.7
        └── current -> atlassian-confluence-5.5.7
```
