### PR TITLE
systemd support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,15 @@ platforms:
   driver:
     box: chef/ubuntu-14.04
     image: ubuntu-14-04-x64
+- name: ubuntu-15.04
+  driver:
+    box: chef/ubuntu-15.04
+    image: ubuntu-15-04-x64
+  attributes:
+    postgresql:
+      # postgresql cookbook doesn't support 15.04 yet.
+      version: '9.4'
+      enable_pgdg_apt: false
 
 provisioner:
   name: chef_zero
@@ -63,6 +72,7 @@ suites:
         type: postgresql
       install_type: standalone
     java:
+      java_home: /usr/lib/jvm/java-8-oracle
       jdk_version: 8
     postgresql:
       password:

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -61,10 +61,30 @@ if settings['database']['type'] == 'mysql'
   mysql_connector_j "#{node['confluence']['install_path']}/lib"
 end
 
-template '/etc/init.d/confluence' do
-  source 'confluence.init.erb'
-  mode '0755'
-  notifies :restart, 'service[confluence]', :delayed
+if node['init_package'] == 'systemd'
+  execute 'systemctl-daemon-reload' do
+    command '/bin/systemctl --system daemon-reload'
+    action :nothing
+  end
+
+  template '/etc/systemd/system/confluence.service' do
+    source 'confluence.systemd.erb'
+    owner 'root'
+    group 'root'
+    mode 00755
+    action :create
+    notifies :run, 'execute[systemctl-daemon-reload]', :immediately
+    notifies :restart, 'service[confluence]', :delayed
+  end
+else
+  template '/etc/init.d/confluence' do
+    source 'confluence.init.erb'
+    owner 'root'
+    group 'root'
+    mode 00755
+    action :create
+    notifies :restart, 'service[confluence]', :delayed
+  end
 end
 
 service 'confluence' do

--- a/templates/default/confluence.systemd.erb
+++ b/templates/default/confluence.systemd.erb
@@ -1,0 +1,13 @@
+[Unit]
+Description=Confluence Team Collaboration Software
+After=network.target
+
+[Service]
+Type=forking
+User=<%= node['confluence']['user'] %>
+PIDFile=<%= node['confluence']['install_path'] %>/work/catalina.pid
+ExecStart=<%= node['confluence']['install_path'] %>/bin/start-confluence.sh
+ExecStop=<%= node['confluence']['install_path'] %>/bin/stop-confluence.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi, 

I've added support for systemd by dropping off a unit file on systemd platforms.

Added Ubuntu 15.04 as a test case, though CentOS 7 is also systemd. Had to add a couple of attributes for postgresql as that cookbook doesn't have support for 15.04 yet.
