### PR TITLE
Added serverspec for test-kitchen 

### DIFF
--- a/test/integration/confluence-standalone-postgresql/serverspec/confluence-standalone-postgresql_spec.rb
+++ b/test/integration/confluence-standalone-postgresql/serverspec/confluence-standalone-postgresql_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'Java' do
+  describe command('java -version 2>&1') do
+    its(:exit_status) { should eq 0 }
+  end
+end
+
+describe 'Postgresql' do
+  describe port(5432) do
+    it { should be_listening }
+  end
+end
+
+describe 'Confluence' do
+  describe port(8090) do
+    it { should be_listening }
+  end
+
+  describe command("curl --noproxy localhost 'http://localhost:8090/setup/setupstart.action' | grep 'Set up Confluence'") do
+    its(:exit_status) { should eq 0 }
+  end
+end
+
+describe 'Apache2' do
+  describe port(80) do
+    it { should be_listening }
+  end
+
+  describe port(443) do
+    it { should be_listening }
+  end
+
+  describe command("curl --insecure --noproxy localhost 'https://localhost/setup/setupstart.action' | grep 'Set up Confluence'") do
+    its(:exit_status) { should eq 0 }
+  end
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec


### PR DESCRIPTION
Hi,

I've added a basic serverspec for the confluence-standalone-postgresql suite. (I notice there are minitest files, but these don't appear to be used.)

Couldn't get confluence-installer-postgresql to converge successfully, haven't tried confluence-installer-mysql yet.
