### PR TITLE
vhost name alias fix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,12 @@ driver:
   require_chef_omnibus: latest
   customize:
     memory: 2048
+  network:
+    # Allow access to the Confluence tomcat ssl webui which is useful when troubleshooting
+    - - forwarded_port
+      - guest: 8443
+        host: 8443
+        auto_correct: true
 
 platforms:
 - name: centos-6

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -25,4 +25,4 @@ include_recipe 'apache2::mod_proxy'
 include_recipe 'apache2::mod_proxy_http'
 include_recipe 'apache2::mod_ssl'
 
-web_app node['confluence']['apache2']['virtual_host_name']
+web_app node['confluence']['apache2']['virtual_host_alias']

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -22,7 +22,7 @@
                    redirectPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['confluence']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['confluence']['apache2']['virtual_host_name'] %>"
                    proxyPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['confluence']['tomcat']['ssl_port'] %>"


### PR DESCRIPTION
Hi! I've swapped the vhost name and aliases, which completes the fix started in dc6c6aa8b654cd1c87be9feee4e95ef3846f29d5. Fixes #44. Fixes #34.

I've also added vagrant port forwarding to the tomcat ssl webui. Port forwarding the apache ssl port is troublesome, as you would then need to set a virtual_host_name of 'localhost:8443' so Tomcat doesn't redirect your browser to https://confluence-standalone-postgresql-ubuntu-1504/
