### PR TITLE
Rename vagrant boxes from "chef" to "bento"

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,24 +8,24 @@ driver:
 platforms:
 - name: centos-6
   driver:
-    box: chef/centos-6.6  # vagrant
+    box: bento/centos-6.7  # vagrant
     image: centos-6-5-x64 # digitalocean
 - name: centos-7
   driver:
-    box: chef/centos-7.1
+    box: bento/centos-7.1
     image: centos-7-0-x64
 
 - name: ubuntu-12.04
   driver:
-    box: chef/ubuntu-12.04
+    box: bento/ubuntu-12.04
     image: ubuntu-12-04-x64
 - name: ubuntu-14.04
   driver:
-    box: chef/ubuntu-14.04
+    box: bento/ubuntu-14.04
     image: ubuntu-14-04-x64
 - name: ubuntu-15.04
   driver:
-    box: chef/ubuntu-15.04
+    box: bento/ubuntu-15.04
     image: ubuntu-15-04-x64
   attributes:
     postgresql:


### PR DESCRIPTION
All vagrant boxes from "chef" account on Atlas have been moved to the "bento" namespace.
I've also bumped a box version for Centos 6: `centos-6.6 -> centos-6.7`.
@patcon  Do you have any concerns?
