### PR TITLE
linux_installer: Enable update flag only if confluence is installed

### DIFF
--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -19,15 +19,18 @@
 
 settings = merge_confluence_settings
 
-template "#{Chef::Config[:file_cache_path]}/atlassian-confluence-response.varfile" do
-  source 'response.varfile.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-end
-
 # Install or upgrade confluence
 if confluence_version != node['confluence']['version']
+  template "#{Chef::Config[:file_cache_path]}/atlassian-confluence-response.varfile" do
+    source 'response.varfile.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables {
+      'update' => Dir.exist?(node['confluence']['install_path'])
+    }
+  end
+
   remote_file "#{Chef::Config[:file_cache_path]}/atlassian-confluence-#{node['confluence']['version']}-#{node['confluence']['arch']}.bin" do
     source node['confluence']['url']
     checksum node['confluence']['checksum']

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -5,7 +5,7 @@
 rmiPort$Long=8000
 app.install.service$Boolean=true
 existingInstallationDir=<%= node['confluence']['install_path'] %>
-sys.confirmedUpdateInstallationString=true
+sys.confirmedUpdateInstallationString=<%= @update ? "true" : "false" %>
 sys.languageId=en
 sys.installationDir=<%= node['confluence']['install_path'] %>
 app.confHome=<%= node['confluence']['home_path'] %>


### PR DESCRIPTION
Otherwise, the installation process will fail
