### PR TITLE
Update mysql cookbook dependency to version 6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,7 +49,7 @@ else
   default['confluence']['apache2']['ssl']['key_file']         = '/etc/ssl/private/ssl-cert-snakeoil.key'
 end
 
-default['confluence']['database']['host']     = 'localhost'
+default['confluence']['database']['host']     = '127.0.0.1'
 default['confluence']['database']['name']     = 'confluence'
 default['confluence']['database']['password'] = 'changeit'
 default['confluence']['database']['type']     = 'mysql'

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ supports 'ubuntu'
 depends 'apache2'
 depends 'ark'
 depends 'database', '~> 2.3'
-depends 'mysql', '~> 5.0'
+depends 'mysql', '~> 6.0'
 depends 'mysql_connector'
 depends 'postgresql'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ supports 'ubuntu'
 
 depends 'apache2'
 depends 'ark'
-depends 'database', '~> 2.3'
+depends 'database'
 depends 'mysql', '~> 6.0'
 depends 'mysql_connector'
 depends 'postgresql'

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -26,8 +26,17 @@ database_connection = {
 
 case settings['database']['type']
 when 'mysql'
-  include_recipe 'mysql::server'
   include_recipe 'database::mysql'
+
+  mysql_service 'confluence' do
+    version settings['database']['version'] if settings['database']['version']
+    bind_address settings['database']['host']
+    port settings['database']['port'].to_s
+    data_dir node['mysql']['data_dir'] if node['mysql']['data_dir']
+    initial_root_password node['mysql']['server_root_password']
+    action [:create, :start]
+  end
+
   database_connection.merge!(:username => 'root', :password => node['mysql']['server_root_password'])
 
   mysql_database settings['database']['name'] do

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -26,7 +26,10 @@ database_connection = {
 
 case settings['database']['type']
 when 'mysql'
-  include_recipe 'database::mysql'
+  mysql2_chef_gem 'confluence' do
+    client_version settings['database']['version'] if settings['database']['version']
+    action :install
+  end
 
   mysql_service 'confluence' do
     version settings['database']['version'] if settings['database']['version']


### PR DESCRIPTION
Implements https://github.com/bflad/chef-confluence/issues/36 
Supersedes https://github.com/bflad/chef-confluence/pull/43 

I think we should either keep these dependencies up-to-date, or remove database management completely from the cookbook (and ask users to manage it by themselves, for example, it in a wrapper cookbook)
