### PR TITLE
Change install path for MySQL JDBC connector

### DIFF
--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -60,8 +60,7 @@ execute 'Generating Self-Signed Java Keystore' do
 end
 
 if settings['database']['type'] == 'mysql'
-  include_recipe 'mysql_connector'
-  mysql_connector_j "#{node['confluence']['install_path']}/lib"
+  mysql_connector_j "#{node['confluence']['install_path']}/confluence/WEB-INF/lib"
 end
 
 if node['init_package'] == 'systemd'

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -62,8 +62,7 @@ ark 'confluence' do
 end
 
 if settings['database']['type'] == 'mysql'
-  include_recipe 'mysql_connector'
-  mysql_connector_j "#{node['confluence']['install_path']}/lib"
+  mysql_connector_j "#{node['confluence']['install_path']}/confluence/WEB-INF/lib"
 end
 
 if node['init_package'] == 'systemd'


### PR DESCRIPTION
Fixes #13

It's done according to the Confluence documentation:
https://confluence.atlassian.com/doc/database-setup-for-mysql-128747.html

Also, there is no need to include "mysql_connector::default" recipe because it is empty.
