### PR TITLE
Set postgres db owner to confluence user.

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -63,22 +63,24 @@ when 'mysql'
     database_name settings['database']['name']
     action [:create, :grant]
   end
+
 when 'postgresql'
   include_recipe 'postgresql::server'
   include_recipe 'database::postgresql'
   database_connection.merge!(:username => 'postgres', :password => node['postgresql']['password']['postgres'])
 
+  postgresql_database_user settings['database']['user'] do
+    connection database_connection
+    password settings['database']['password']
+    action :create
+  end
+
   postgresql_database settings['database']['name'] do
     connection database_connection
     connection_limit '-1'
     encoding 'utf8'
+    owner settings['database']['user']
     action :create
   end
 
-  postgresql_database_user settings['database']['user'] do
-    connection database_connection
-    password settings['database']['password']
-    database_name settings['database']['name']
-    action [:create, :grant]
-  end
 end


### PR DESCRIPTION
- This allows a database to be imported using a more flexible backup,
  taken with the `--no-owner` flag. However, in order for the new
  database to work as expected, the database my be owned by the user
  expected to interact with it. This way, the table ownership is
  automatically set to this db user during import, and this db user can
  continue to access later.
