### PR TITLE
TravisCI: Use container-based infrastructure + Berkshelf 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Use container-based infrastructure in Travis
+sudo: false
+
 language: ruby
 bundler_args: --without integration
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 group :test, :integration do
-  gem 'berkshelf', '~> 3.0'
+  gem 'berkshelf', '~> 4.0'
 end
 
 group :test do


### PR DESCRIPTION
- TravisCI: Use container-based infrastructure
  More info: http://docs.travis-ci.com/user/migrating-from-legacy/
- Update Berkshelf to 4.0 in order to fix an error https://github.com/berkshelf/berkshelf/issues/1466
