### PR TITLE
Move duplicated resources to the "configuration" recipe

### DIFF
--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -17,9 +17,47 @@
 # limitations under the License.
 #
 
+settings = merge_confluence_settings
+
 template "#{node['confluence']['install_path']}/confluence/WEB-INF/classes/confluence-init.properties" do
   source 'confluence-init.properties.erb'
   owner node['confluence']['user']
   mode '0644'
   notifies :restart, 'service[confluence]', :delayed
+end
+
+if settings['database']['type'] == 'mysql'
+  mysql_connector_j "#{node['confluence']['install_path']}/confluence/WEB-INF/lib"
+end
+
+if node['init_package'] == 'systemd'
+  execute 'systemctl-daemon-reload' do
+    command '/bin/systemctl --system daemon-reload'
+    action :nothing
+  end
+
+  template '/etc/systemd/system/confluence.service' do
+    source 'confluence.systemd.erb'
+    owner 'root'
+    group 'root'
+    mode 00755
+    action :create
+    notifies :run, 'execute[systemctl-daemon-reload]', :immediately
+    notifies :restart, 'service[confluence]', :delayed
+  end
+else
+  template '/etc/init.d/confluence' do
+    source 'confluence.init.erb'
+    owner 'root'
+    group 'root'
+    mode 00755
+    action :create
+    notifies :restart, 'service[confluence]', :delayed
+  end
+end
+
+service 'confluence' do
+  supports :status => true, :restart => true
+  action :enable
+  subscribes :restart, 'java_ark[jdk]'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,6 @@ settings = merge_confluence_settings
 
 include_recipe 'confluence::database' if settings['database']['host'] == '127.0.0.1'
 include_recipe "confluence::linux_#{node['confluence']['install_type']}"
+include_recipe 'confluence::configuration'
 include_recipe 'confluence::tomcat_configuration'
 include_recipe 'confluence::apache2'
-include_recipe 'confluence::configuration'

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -60,38 +60,3 @@ execute 'Generating Self-Signed Java Keystore' do
   creates settings['tomcat']['keystoreFile']
   only_if { settings['tomcat']['keystoreFile'] == "#{node['confluence']['home_path']}/.keystore" }
 end
-
-if settings['database']['type'] == 'mysql'
-  mysql_connector_j "#{node['confluence']['install_path']}/confluence/WEB-INF/lib"
-end
-
-if node['init_package'] == 'systemd'
-  execute 'systemctl-daemon-reload' do
-    command '/bin/systemctl --system daemon-reload'
-    action :nothing
-  end
-
-  template '/etc/systemd/system/confluence.service' do
-    source 'confluence.systemd.erb'
-    owner 'root'
-    group 'root'
-    mode 00755
-    action :create
-    notifies :run, 'execute[systemctl-daemon-reload]', :immediately
-    notifies :restart, 'service[confluence]', :delayed
-  end
-else
-  template '/etc/init.d/confluence' do
-    source 'confluence.init.erb'
-    owner 'root'
-    group 'root'
-    mode 00755
-    action :create
-    notifies :restart, 'service[confluence]', :delayed
-  end
-end
-
-service 'confluence' do
-  supports :status => true, :restart => true
-  action :enable
-end

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -62,39 +62,3 @@ ark 'confluence' do
   owner node['confluence']['user']
   group node['confluence']['user']
 end
-
-if settings['database']['type'] == 'mysql'
-  mysql_connector_j "#{node['confluence']['install_path']}/confluence/WEB-INF/lib"
-end
-
-if node['init_package'] == 'systemd'
-  execute 'systemctl-daemon-reload' do
-    command '/bin/systemctl --system daemon-reload'
-    action :nothing
-  end
-
-  template '/etc/systemd/system/confluence.service' do
-    source 'confluence.systemd.erb'
-    owner 'root'
-    group 'root'
-    mode 00755
-    action :create
-    notifies :run, 'execute[systemctl-daemon-reload]', :immediately
-    notifies :restart, 'service[confluence]', :delayed
-  end
-else
-  template '/etc/init.d/confluence' do
-    source 'confluence.init.erb'
-    owner 'root'
-    group 'root'
-    mode 00755
-    action :create
-    notifies :restart, 'service[confluence]', :delayed
-  end
-end
-
-service 'confluence' do
-  supports :status => true, :restart => true
-  action :enable
-  subscribes :restart, 'java_ark[jdk]'
-end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,6 +2,20 @@ require 'spec_helper'
 
 describe 'confluence::configuration' do
   let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
+    ChefSpec::SoloRunner.new do |node|
+      node.set['confluence']['install_path'] = '/opt/atlassian/confluence'
+      node.set['confluence']['home_path'] = '/var/atlassian/application-data/confluence'
+    end.converge(described_recipe)
+  end
+
+  it 'renders confluence-init.properties' do
+    expect(chef_run).to render_file('/opt/atlassian/confluence/confluence/WEB-INF/classes/confluence-init.properties')
+      .with_content { |content|
+        expect(content).to include('confluence.home=/var/atlassian/application-data/confluence')
+      }
+  end
+
+  it 'enables Confluence service' do
+    expect(chef_run).to enable_service('confluence')
   end
 end


### PR DESCRIPTION
IMO, there is no need to split an init script management and `mysql_connector_j` to different recipes
Following the [KISS](https://en.wikipedia.org/wiki/KISS_principle), let's just keep it in the single place, `configuration.rb`
