### PR TITLE
Disable https on the Tomcat side

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,9 @@ java_opts | additional JAVA_OPTS to be passed to Confluence JVM during startup |
 
 These attributes are under the `node['confluence']['tomcat']` namespace.
 
-Any `node['confluence']['tomcat']['key*']` attributes are overridden by `confluence/confluence` encrypted data bag (Hosted Chef) or data bag (Chef Solo), if it exists
-
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
-keyAlias | Tomcat SSL keystore alias | String | tomcat
-keystoreFile | Tomcat SSL keystore file - will automatically generate self-signed keystore file if left as default | String | `#{node['confluence']['home_path']}/.keystore`
-keystorePass | Tomcat SSL keystore passphrase | String | changeit
 port | Tomcat HTTP port | Fixnum | 8090
-ssl_port | Tomcat HTTPS port | Fixnum | 8443
 
 ## Recipes
 
@@ -140,11 +134,6 @@ Repeat for other Chef environments as necessary. Example:
           "name": "confluence",
           "user": "confluence",
           "password": "confluence_db_password",
-        },
-        "tomcat": {
-          "keyAlias": "not_tomcat",
-          "keystoreFile": "/etc/pki/java/wildcard_cert.jks",
-          "keystorePass": "not_changeit"
         }
       }
     }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,8 +58,4 @@ default['confluence']['jvm']['maximum_memory']  = '512m'
 default['confluence']['jvm']['maximum_permgen'] = '256m'
 default['confluence']['jvm']['java_opts']       = ''
 
-default['confluence']['tomcat']['keyAlias']     = 'tomcat'
-default['confluence']['tomcat']['keystoreFile'] = "#{node['confluence']['home_path']}/.keystore"
-default['confluence']['tomcat']['keystorePass'] = 'changeit'
 default['confluence']['tomcat']['port']         = '8090'
-default['confluence']['tomcat']['ssl_port']     = '8443'

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-settings = merge_confluence_settings
-
 # Install or upgrade confluence
 if confluence_version != node['confluence']['version']
   template "#{Chef::Config[:file_cache_path]}/atlassian-confluence-response.varfile" do
@@ -44,19 +42,4 @@ if confluence_version != node['confluence']['version']
     cwd Chef::Config[:file_cache_path]
     command "./atlassian-confluence-#{node['confluence']['version']}.bin -q -varfile atlassian-confluence-response.varfile"
   end
-end
-
-execute 'Generating Self-Signed Java Keystore' do
-  command <<-COMMAND
-    #{node['confluence']['install_path']}/jre/bin/keytool -genkey \
-      -alias #{settings['tomcat']['keyAlias']} \
-      -keyalg RSA \
-      -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \
-      -keypass #{settings['tomcat']['keystorePass']} \
-      -storepass #{settings['tomcat']['keystorePass']} \
-      -keystore #{settings['tomcat']['keystoreFile']}
-    chown #{node['confluence']['user']}:#{node['confluence']['user']} #{settings['tomcat']['keystoreFile']}
-  COMMAND
-  creates settings['tomcat']['keystoreFile']
-  only_if { settings['tomcat']['keystoreFile'] == "#{node['confluence']['home_path']}/.keystore" }
 end

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-settings = merge_confluence_settings
-
 directory File.dirname(node['confluence']['home_path']) do
   owner 'root'
   group 'root'
@@ -34,21 +32,6 @@ user node['confluence']['user'] do
   supports :manage_home => true
   system true
   action :create
-end
-
-execute 'Generating Self-Signed Java Keystore' do
-  command <<-COMMAND
-    #{node['java']['java_home']}/bin/keytool -genkey \
-      -alias #{settings['tomcat']['keyAlias']} \
-      -keyalg RSA \
-      -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \
-      -keypass #{settings['tomcat']['keystorePass']} \
-      -storepass #{settings['tomcat']['keystorePass']} \
-      -keystore #{settings['tomcat']['keystoreFile']}
-    chown #{node['confluence']['user']}:#{node['confluence']['user']} #{settings['tomcat']['keystoreFile']}
-  COMMAND
-  creates settings['tomcat']['keystoreFile']
-  only_if { settings['tomcat']['keystoreFile'] == "#{node['confluence']['home_path']}/.keystore" }
 end
 
 Chef::Resource::Ark.send(:include, Confluence::Helpers)

--- a/recipes/tomcat_configuration.rb
+++ b/recipes/tomcat_configuration.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-settings = merge_confluence_settings
-
 template "#{node['confluence']['install_path']}/bin/setenv.sh" do
   source 'setenv.sh.erb'
   owner node['confluence']['user']
@@ -30,7 +28,6 @@ template "#{node['confluence']['install_path']}/conf/server.xml" do
   source 'server.xml.erb'
   owner node['confluence']['user']
   mode '0640'
-  variables :tomcat => settings['tomcat']
   notifies :restart, 'service[confluence]', :delayed
 end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,6 +2,51 @@ require 'spec_helper'
 
 describe 'confluence::default' do
   let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
+    ChefSpec::SoloRunner.new do |node|
+      node.set['confluence']['install_path'] = '/opt/atlassian/confluence'
+      node.set['confluence']['home_path'] = '/var/atlassian/application-data/confluence'
+      node.set['mysql']['server_root_password'] = 'foo'
+    end.converge(described_recipe)
+  end
+
+  before do
+    stub_command('/usr/sbin/apache2 -t').and_return(true)
+  end
+
+  it 'renders server.xml' do
+    path = '/opt/atlassian/confluence/conf/server.xml'
+    resource = chef_run.template(path)
+
+    expect(resource).to notify('service[confluence]').to(:restart)
+    expect(chef_run).to render_file(path)
+  end
+
+  it 'renders web.xml' do
+    path = '/opt/atlassian/confluence/conf/web.xml'
+    resource = chef_run.template(path)
+
+    expect(resource).to notify('service[confluence]').to(:restart)
+    expect(chef_run).to render_file(path)
+  end
+
+  context 'for "installer" installation type' do
+    it 'uses the bundled JRE' do
+      expect(chef_run).to render_file('/opt/atlassian/confluence/bin/setenv.sh')
+        .with_content { |content|
+          expect(content).to include('JRE_HOME="/opt/atlassian/confluence/jre/"')
+        }
+    end
+  end
+
+  context 'for "standalone" installation type' do
+    it 'uses JRE managed by "java" cookbook' do
+      chef_run.node.set['java']['java_home'] = '/usr/lib/jvm/java'
+      chef_run.node.set['confluence']['install_type'] = 'standalone'
+
+      expect(chef_run).to render_file('/opt/atlassian/confluence/bin/setenv.sh')
+        .with_content { |content|
+          expect(content).to include('JRE_HOME="/usr/lib/jvm/java/jre/"')
+        }
+    end
   end
 end

--- a/spec/tomcat_configuration_spec.rb
+++ b/spec/tomcat_configuration_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe 'confluence::tomcat_configuration' do
-  let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
-  end
-end

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -18,35 +18,11 @@
                    useBodyEncodingForURI="true"
                    compression="on"
                    compressableMimeType="text/html,text/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"
-                   <% if node['confluence']['apache2'] -%>
-                   redirectPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
                    proxyName="<%= node['confluence']['apache2']['virtual_host_name'] %>"
                    proxyPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
-                   <% else -%>
-                   redirectPort="<%= node['confluence']['tomcat']['ssl_port'] %>"
-                   <% end -%>
-        />
-
-        <Connector port="<%= node['confluence']['tomcat']['ssl_port'] %>"
-             maxHttpHeaderSize="8192"
-             maxThreads="150"
-             minSpareThreads="25"
-             maxSpareThreads="75"
-             enableLookups="false"
-             disableUploadTimeout="true"
-             acceptCount="100"
-             scheme="https"
-             secure="true"
-             clientAuth="false"
-             SSLEnabled="true"
-             sslProtocol="TLS"
-             <%- if @tomcat %>
-             <%= "keyAlias=\"#{@tomcat['keyAlias']}\"" if @tomcat['keyAlias'] %>
-             <%= "keystoreFile=\"#{@tomcat['keystoreFile']}\"" if @tomcat['keystoreFile'] %>
-             <%= "keystorePass=\"#{@tomcat['keystorePass']}\"" if @tomcat['keystorePass'] %>
-             <%- end %>
+                   redirectPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
         />
 
         <Engine name="Standalone" defaultHost="localhost" debug="0">


### PR DESCRIPTION
Production instances of Confluence usually use some web server as a reverse proxy at the front of Tomcat.
In this cookbook we also configure Apache web server for these needs.

So, since https is actually terminating on the Apache side, there are no needs to manage keystore
and configure TLS/SSL on the Tomcat side.

This is the analogue of jira's PR: https://github.com/afklm/jira/pull/30
