### PR TITLE
Added Crowd SSO support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   [[GH-41]](https://github.com/bflad/chef-confluence/issues/41)
 * Implemented ark cookbook with install directory versioning.
   [[GH-40]](https://github.com/bflad/chef-confluence/issues/40)
+* Added Crowd SSO support.
+  [[GH-26]](https://github.com/parallels-cookbooks/confluence/pull/26)
 
 ## 1.7.1
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ port | Tomcat HTTP port | Fixnum | 8090
 * `recipe[confluence::linux_installer]` Installs/configures Confluence via Linux installer"
 * `recipe[confluence::linux_standalone]` Installs/configures Confluence via Linux standalone archive"
 * `recipe[confluence::tomcat_configuration]` Configures Confluence's built-in Tomcat
+* `recipe[confluence::crowd_sso]` Configures Crowd single sign-on
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,8 @@ default['confluence']['jvm']['maximum_permgen'] = '256m'
 default['confluence']['jvm']['java_opts']       = ''
 
 default['confluence']['tomcat']['port']         = '8090'
+
+default['confluence']['crowd_sso']['enabled'] = false
+default['confluence']['crowd_sso']['app_name'] = nil
+default['confluence']['crowd_sso']['app_password'] = nil
+default['confluence']['crowd_sso']['crowd_base_url'] = 'http://crowd.example.com:8095/crowd'

--- a/recipes/crowd_sso.rb
+++ b/recipes/crowd_sso.rb
@@ -1,0 +1,31 @@
+template "#{node['confluence']['install_path']}/confluence/WEB-INF/classes/crowd.properties" do
+  source 'crowd.properties.erb'
+  owner node['confluence']['user']
+  group node['confluence']['user']
+  mode 00644
+  action :create
+  variables(
+    :app_name => node['confluence']['crowd_sso']['app_name'],
+    :app_password => node['confluence']['crowd_sso']['app_password'],
+    :crowd_base_url => node['confluence']['crowd_sso']['crowd_base_url']
+  )
+  sensitive true
+  notifies :restart, 'service[confluence]', :delayed
+end
+
+# Update config to activate Crowd's authenticator to enable SSO
+# See: https://confluence.atlassian.com/display/CROWD/Integrating+Crowd+with+Atlassian+Confluence
+
+default_fragment = '<authenticator class="com.atlassian.confluence.user.ConfluenceAuthenticator"/>'
+sso_fragment = '<authenticator class="com.atlassian.confluence.user.ConfluenceCrowdSSOAuthenticator"/>'
+
+ruby_block 'Set Crowd authenticator' do
+  block do
+    fe = Chef::Util::FileEdit.new("#{node['confluence']['install_path']}/confluence/WEB-INF/classes/seraph-config.xml")
+    fe.search_file_replace(/#{Regexp.quote(default_fragment)}/, sso_fragment)
+    fe.write_file
+  end
+  only_if %Q(grep '#{default_fragment}' \
+    #{node['confluence']['install_path']}/confluence/WEB-INF/classes/seraph-config.xml)
+  notifies :restart, 'service[confluence]', :delayed
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,3 +24,4 @@ include_recipe "confluence::linux_#{node['confluence']['install_type']}"
 include_recipe 'confluence::configuration'
 include_recipe 'confluence::tomcat_configuration'
 include_recipe 'confluence::apache2'
+include_recipe 'confluence::crowd_sso' if node['confluence']['crowd_sso']['enabled']

--- a/templates/default/crowd.properties.erb
+++ b/templates/default/crowd.properties.erb
@@ -1,0 +1,13 @@
+<!-- This file is maintained by Chef. Please do not edit manually. -->
+
+application.name                        <%= @app_name %>
+application.password                    <%= @app_password %>
+application.login.url                   <%= File.join(@crowd_base_url, 'console') %>
+
+crowd.server.url                        <%= File.join(@crowd_base_url, 'services') %>
+crowd.base.url                          <%= @crowd_base_url %>
+
+session.isauthenticated                 session.isauthenticated
+session.tokenkey                        session.tokenkey
+session.validationinterval              2
+session.lastvalidation                  session.lastvalidation


### PR DESCRIPTION
See #26

This takes the same approach as taken here:
https://github.com/afklm/jira/issues/22

(Note that disabling crowd isn't supported in this PR. We could add this, but it would be a bit messier.)

We could also use the `line` resource cookbook to make this cleaner, if we didn't mind adding the dependency. I realize that using templates is often preferred, but since it was a small change, I thought this would be better, and so it would work across more version of confluence (where the `seraph-config.xml` might change)
