### PR TITLE
Proposal: Improve data bag approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,39 +110,37 @@ port | Tomcat HTTP port | Fixnum | 8090
 
 ## Usage
 
-### Confluence Server Data Bag
+### Confluence Data Bag
 
-For securely overriding attributes on Hosted Chef, create a `confluence/confluence` encrypted data bag with the model below. Chef Solo can override the same attributes with a `confluence/confluence` unencrypted data bag of the same information.
+For security purposes it is recommended to use data bag for storing secrets
+like passwords and database credentials.
 
-_required:_
-* `['database']['type']` "mysql" or "postgresql"
-* `['database']['host']` FQDN or "localhost" (localhost automatically
-  installs `['database']['type']` server)
-* `['database']['name']` Name of Confluence database
-* `['database']['user']` Confluence database username
-* `['database']['password']` Confluence database username password
+You can override any attributes from the `['confluence']` namespace using the
+`confluence/confluence` data bag. It could be either encrypted or not
+encrypted by your choice.
 
-_optional:_
-* `['database']['port']` Database port, standard database port for
-  `['database']['type']`
-* `['tomcat']['keyAlias']` Tomcat HTTPS Java Keystore keyAlias, defaults to self-signed certifcate
-* `['tomcat']['keystoreFile']` Tomcat HTTPS Java Keystore keystoreFile, self-signed certificate
-* `['tomcat']['keystorePass']` Tomcat HTTPS Java Keystore keystorePass, self-signed certificate
-
-Repeat for other Chef environments as necessary. Example:
-
-    {
-      "id": "confluence"
-      "development": {
-        "database": {
-          "type": "postgresql",
-          "host": "localhost",
-          "name": "confluence",
-          "user": "confluence",
-          "password": "confluence_db_password",
-        }
-      }
+Example:
+```json
+{
+  "id": "confluence",
+  "confluence": {
+    "database": {
+      "type": "postgresql",
+      "host": "localhost",
+      "name": "confluence_db",
+      "user": "confluence_user",
+      "password": "confluence_db_password",
     }
+  }
+}
+```
+_(Note - `"confluence"` nesting level is required!)_
+
+These credentials will be used for your Confluence installation instead of
+appropriate attribute values.
+
+Data bag's and item's names are optional and can be changed by overriding
+attributes `['confluence']['data_bag_name']` and `['confluence']['data_bag_item']`
 
 ### Confluence Server Installation
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,10 @@ default['confluence']['version']        = '5.8.13'
 default['confluence']['url']            = nil
 default['confluence']['checksum']       = nil
 
+# Data bag where credentials and other sensitive data could be stored (optional)
+default['confluence']['data_bag_name'] = 'confluence'
+default['confluence']['data_bag_item'] = 'confluence'
+
 default['confluence']['apache2']['access_log']         = ''
 default['confluence']['apache2']['error_log']          = ''
 default['confluence']['apache2']['port']               = 80

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -69,12 +69,12 @@ module Confluence
           Chef::DataBagItem.load(
             node['confluence']['data_bag_name'],
             node['confluence']['data_bag_name']
-          )['local']
+          )['confluence']
         else
           Chef::EncryptedDataBagItem.load(
             node['confluence']['data_bag_name'],
             node['confluence']['data_bag_name']
-          )[node.chef_environment]
+          )['confluence']
         end
       rescue
         Chef::Log.info('No confluence data bag found')

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -66,9 +66,15 @@ module Confluence
       item =
       begin
         if Chef::Config[:solo]
-          Chef::DataBagItem.load('confluence', 'confluence')['local']
+          Chef::DataBagItem.load(
+            node['confluence']['data_bag_name'],
+            node['confluence']['data_bag_name']
+          )['local']
         else
-          Chef::EncryptedDataBagItem.load('confluence', 'confluence')[node.chef_environment]
+          Chef::EncryptedDataBagItem.load(
+            node['confluence']['data_bag_name'],
+            node['confluence']['data_bag_name']
+          )[node.chef_environment]
         end
       rescue
         Chef::Log.info('No confluence data bag found')

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -63,25 +63,14 @@ module Confluence
     #
     # @return [Hash] Settings hash
     def settings_from_data_bag
-      item =
       begin
-        if Chef::Config[:solo]
-          Chef::DataBagItem.load(
-            node['confluence']['data_bag_name'],
-            node['confluence']['data_bag_name']
-          )['confluence']
-        else
-          Chef::EncryptedDataBagItem.load(
-            node['confluence']['data_bag_name'],
-            node['confluence']['data_bag_name']
-          )['confluence']
-        end
+        item = data_bag_item(node['confluence']['data_bag_name'],
+                             node['confluence']['data_bag_item'])['confluence']
+        return item if item.is_a?(Hash)
       rescue
         Chef::Log.info('No confluence data bag found')
-        nil
       end
-
-      item || {}
+      {}
     end
 
     # Returns download URL for Confluence artifact


### PR DESCRIPTION
**This PR contains a breaking change, so it can be merged only in the scope of major version bump.**

**1)** Add attributes `['confluence']['data_bag_name']` and `['confluence']['data_bag_item']`. Finally, they will be optional and users will be able to change data bag and item names.

**2)** Allow to use as well as encrypted and not encrypted data bags regardless of Chef Client type.
   **Breaking:** In old Chef clients (< 12.0.0) `data_bag_item` method couldn't be used for encrypted data bag. So, in this case settings will be defined by attributes, not by data bag values. 

**3)** Use `confluence` nesting level in data bag instead of `'local'` or `node.chef_environment`.
At this moment it is not predictable - the library method tries to fetch `local` nested dictionary if it is called by Chef Solo. Otherwise, it fetches dictionary `node.environment`. I suggest to use an explicit name, `"confluence"`, which is the cookbook name. 
Also, it will be easier for users to understand how data bag values are overriding the appropriate attributes. The logic is: _"If I want to override `['confluence']['database']['password']` and `['confluence']['database']['user']` via data bag, then I have to set these values on the same nesting level in the data bag"._
Example:

``` json
{
  "id": "confluence",
  "confluence": {
    "database": {
      "user": "some_user",
      "password": "some_password"
    }
  }
}
```

**Breaking:** Those who use `confluence/confluence` data bag with this cookbook, will have to change the name of the nested dictionary from their current Chef environment to `"confluence"`. 
If they still want to have environment-specific configuration, they can rename the data bag item to env name and then override this attribute:

``` ruby
node.set['confluence']['data_bag_item'] = node.chef_environment
```

@racktear @Kasen @patcon Please, take a look. Suggestions are welcome!

@mvdkleijn @linc01n I'd like to suggest you to do the similar changes in JIRA and Stash cookbooks appropriately. I'm ready to send PR to your cookbooks if you don't mind.
