### PR TITLE
Allow to override SSO settings in the data bag

### DIFF
--- a/recipes/crowd_sso.rb
+++ b/recipes/crowd_sso.rb
@@ -1,3 +1,5 @@
+settings = merge_confluence_settings
+
 template "#{node['confluence']['install_path']}/confluence/WEB-INF/classes/crowd.properties" do
   source 'crowd.properties.erb'
   owner node['confluence']['user']
@@ -5,9 +7,9 @@ template "#{node['confluence']['install_path']}/confluence/WEB-INF/classes/crowd
   mode 00644
   action :create
   variables(
-    :app_name => node['confluence']['crowd_sso']['app_name'],
-    :app_password => node['confluence']['crowd_sso']['app_password'],
-    :crowd_base_url => node['confluence']['crowd_sso']['crowd_base_url']
+    :app_name => settings['crowd_sso']['app_name'],
+    :app_password => settings['crowd_sso']['app_password'],
+    :crowd_base_url => settings['crowd_sso']['crowd_base_url']
   )
   sensitive true
   notifies :restart, 'service[confluence]', :delayed

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,4 +24,4 @@ include_recipe "confluence::linux_#{node['confluence']['install_type']}"
 include_recipe 'confluence::configuration'
 include_recipe 'confluence::tomcat_configuration'
 include_recipe 'confluence::apache2'
-include_recipe 'confluence::crowd_sso' if node['confluence']['crowd_sso']['enabled']
+include_recipe 'confluence::crowd_sso' if settings['crowd_sso']['enabled']


### PR DESCRIPTION
It works by the same way as "database" stuff.
SSO credentials are sensitive data, so it's recommended to store them in the encrypted data bag.
