### PR TITLE
Use helper functions for host-related attributes that are currently derived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   [[GH-26]](https://github.com/parallels-cookbooks/confluence/pull/26)
 * Create database connection helper.
   [[GH-61]](https://github.com/parallels-cookbooks/confluence/pull/61)
+* Converted `virtual_host_name` and `virtual_host_alias` derived attrs
+  into helper methods for templates, etc.
+  [[GH-81]](https://github.com/parallels-cookbooks/confluence/pull/81)
 
 ## 1.7.1
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,8 +34,10 @@ default['confluence']['data_bag_item'] = 'confluence'
 default['confluence']['apache2']['access_log']         = ''
 default['confluence']['apache2']['error_log']          = ''
 default['confluence']['apache2']['port']               = 80
-default['confluence']['apache2']['virtual_host_name']  = node['fqdn']
-default['confluence']['apache2']['virtual_host_alias'] = node['hostname']
+
+# Defaults are automatically selected from fqdn and hostname via helper functions
+default['confluence']['apache2']['virtual_host_name']  = nil
+default['confluence']['apache2']['virtual_host_alias'] = nil
 
 default['confluence']['apache2']['ssl']['access_log']       = ''
 default['confluence']['apache2']['ssl']['chain_file']       = ''

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -36,6 +36,14 @@ module Confluence
       end
     end
 
+    def confluence_virtual_host_name
+      node['confluence']['apache2']['virtual_host_name'] || node['fqdn']
+    end
+
+    def confluence_virtual_host_alias
+      node['confluence']['apache2']['virtual_host_alias'] || node['hostname']
+    end
+
     # rubocop:disable Metrics/AbcSize
     def confluence_database_connection
       settings = merge_confluence_settings
@@ -270,3 +278,4 @@ end
 
 ::Chef::Recipe.send(:include, Confluence::Helpers)
 ::Chef::Resource.send(:include, Confluence::Helpers)
+::Chef::Mixin::Template::TemplateContext.send(:include, Confluence::Helpers)

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -25,4 +25,4 @@ include_recipe 'apache2::mod_proxy'
 include_recipe 'apache2::mod_proxy_http'
 include_recipe 'apache2::mod_ssl'
 
-web_app node['confluence']['apache2']['virtual_host_alias']
+web_app confluence_virtual_host_alias

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -20,7 +20,7 @@
                    compressableMimeType="text/html,text/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['confluence']['apache2']['virtual_host_name'] %>"
+                   proxyName="<%= confluence_virtual_host_name %>"
                    proxyPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
                    redirectPort="<%= node['confluence']['apache2']['ssl']['port'] %>"
         />

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -3,12 +3,11 @@
 #  Local modifications will be overwritten by Chef.
 #
 <VirtualHost *:<%= node['confluence']['apache2']['port'] %>>
-	<% unless node['confluence']['apache2']['virtual_host_name'].empty? -%>
-	ServerName <%= node['confluence']['apache2']['virtual_host_name'] %>
+	<% unless confluence_virtual_host_name.nil? || confluence_virtual_host_name.empty? -%>
+	ServerName <%= confluence_virtual_host_name %>
 	<% end -%>
-	<% unless node['confluence']['apache2']['virtual_host_alias'].empty? -%>
-	<% virtual_host_aliases = node['confluence']['apache2']['virtual_host_alias'].kind_of?(Array) ? node['confluence']['apache2']['virtual_host_alias'] : [ node['confluence']['apache2']['virtual_host_alias'] ] -%>
-	<% virtual_host_aliases.each do |virtual_host_alias| -%>
+	<% unless confluence_virtual_host_alias.empty? -%>
+	<% Array(confluence_virtual_host_alias).each do |virtual_host_alias| -%>
 	ServerAlias <%= virtual_host_alias %>
 	<% end -%>
 	<% end -%>
@@ -24,12 +23,11 @@
 </VirtualHost>
 
 <VirtualHost *:<%= node['confluence']['apache2']['ssl']['port'] %>>
-	<% unless node['confluence']['apache2']['virtual_host_name'].empty? -%>
-	ServerName <%= node['confluence']['apache2']['virtual_host_name'] %>
+	<% unless confluence_virtual_host_name.nil? || confluence_virtual_host_name.empty? -%>
+	ServerName <%= confluence_virtual_host_name %>
 	<% end -%>
-	<% unless node['confluence']['apache2']['virtual_host_alias'].empty? -%>
-	<% virtual_host_aliases = node['confluence']['apache2']['virtual_host_alias'].kind_of?(Array) ? node['confluence']['apache2']['virtual_host_alias'] : [ node['confluence']['apache2']['virtual_host_alias'] ] -%>
-	<% virtual_host_aliases.each do |virtual_host_alias| -%>
+	<% unless confluence_virtual_host_alias.empty? -%>
+	<% Array(confluence_virtual_host_alias).each do |virtual_host_alias| -%>
 	ServerAlias <%= virtual_host_alias %>
 	<% end -%>
 	<% end -%>


### PR DESCRIPTION
We're currently using derived attributes for `virtual_host_alias` and `virtual_host_name`, which makes it cumbersome to deploy on some platforms where the hostname needs to be set. This PR ensures that FQDN and hostname can be set, and our attributes inherit as expected.
