### PR TITLE
test/integration: Use "infrataster" to check website availability

### DIFF
--- a/test/integration/helpers/serverspec/Gemfile
+++ b/test/integration/helpers/serverspec/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'infrataster'

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,15 +1,14 @@
 require 'serverspec'
+require 'infrataster/rspec'
 
 set :backend, :exec
+
+Infrataster::Server.define(:confluence_web, '127.0.0.1')
 
 shared_examples_for 'confluence behind the apache proxy' do
   describe 'Tomcat' do
     describe port(8090) do
       it { should be_listening }
-    end
-
-    describe command("curl --noproxy localhost 'http://localhost:8090/setup/setupstart.action' | grep 'Set up Confluence'") do
-      its(:exit_status) { should eq 0 }
     end
   end
 
@@ -21,9 +20,28 @@ shared_examples_for 'confluence behind the apache proxy' do
     describe port(443) do
       it { should be_listening }
     end
+  end
 
-    describe command("curl --insecure --noproxy localhost 'https://localhost/setup/setupstart.action' | grep 'Set up Confluence'") do
-      its(:exit_status) { should eq 0 }
+  describe server(:confluence_web) do
+    describe http('http://127.0.0.1/setup/setupstart.action') do
+      it 'redirects 80 port to 443' do
+        expect(response.status).to eq(302)
+        expect(response.headers['location']).to eq('https://127.0.0.1/setup/setupstart.action')
+      end
+    end
+
+    describe http('https://127.0.0.1/setup/setupstart.action', ssl: {verify: false}) do
+      it 'returns setup wizard' do
+        expect(response.status).to eq(200)
+        expect(response.body).to include('Set up Confluence')
+      end
+    end
+
+    describe http('http://127.0.0.1:8090/setup/setupstart.action') do
+      it 'returns setup wizard' do
+        expect(response.status).to eq(200)
+        expect(response.body).to include('Set up Confluence')
+      end
     end
   end
 end


### PR DESCRIPTION
`curl` could be not installed on the target platform (for example, Ubuntu 14.04). 
So, it's better to use a special gem for testing HTTP responses.

cc: @Kasen 
