### PR TITLE
Add fixture cookbook for integration tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,7 @@ platforms:
   driver:
     box: bento/centos-6.7  # vagrant
     image: centos-6-5-x64 # digitalocean
+
 - name: centos-7
   driver:
     box: bento/centos-7.1
@@ -25,23 +26,13 @@ platforms:
   driver:
     box: bento/ubuntu-12.04
     image: ubuntu-12-04-x64
+
 - name: ubuntu-14.04
   run_list:
     - recipe[apt]
   driver:
     box: bento/ubuntu-14.04
     image: ubuntu-14-04-x64
-- name: ubuntu-15.04
-  run_list:
-    - recipe[apt]
-  driver:
-    box: bento/ubuntu-15.04
-    image: ubuntu-15-04-x64
-  attributes:
-    postgresql:
-      # postgresql cookbook doesn't support 15.04 yet.
-      version: '9.4'
-      enable_pgdg_apt: false
 
 provisioner:
   name: chef_zero

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,57 +48,31 @@ provisioner:
   attributes:
     java:
       install_flavor: oracle
-      java_home: /usr/lib/jvm/java-7-oracle
-      jdk_version: 7
+      jdk_version: 8
       oracle:
         accept_oracle_download_terms: true
 
 suites:
 - name: installer-mysql
   run_list:
-  - recipe[confluence]
-  attributes:
-    mysql:
-      server_root_password: iloverandompasswordsbutthiswilldo
+  - recipe[confluence_test::mysql]
 
 - name: installer-postgresql
   run_list:
-  - recipe[confluence]
-  attributes:
-    confluence:
-      database:
-        type: postgresql
-    postgresql:
-      password:
-        postgres: iloverandompasswordsbutthiswilldo
+  - recipe[confluence_test::postgresql]
 
 - name: standalone-mysql
   run_list:
   - recipe[java]
-  - recipe[confluence]
+  - recipe[confluence_test::mysql]
   attributes:
     confluence:
-      database:
-        type: mysql
       install_type: standalone
-    java:
-      java_home: /usr/lib/jvm/java-8-oracle
-      jdk_version: 8
-    mysql:
-      server_root_password: iloverandompasswordsbutthiswilldo
 
 - name: standalone-postgresql
   run_list:
   - recipe[java]
-  - recipe[confluence]
+  - recipe[confluence_test::postgresql]
   attributes:
     confluence:
-      database:
-        type: postgresql
       install_type: standalone
-    java:
-      java_home: /usr/lib/jvm/java-8-oracle
-      jdk_version: 8
-    postgresql:
-      password:
-        postgres: iloverandompasswordsbutthiswilldo

--- a/Berksfile
+++ b/Berksfile
@@ -2,5 +2,12 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'apt'
-cookbook 'java'
+group :integration do
+  cookbook 'apt'
+  cookbook 'java'
+  cookbook 'confluence_test', path: 'test/fixtures/cookbooks/confluence_test'
+
+  # Lock 'postgresql' version due to the issue of derived attributes
+  # https://github.com/hw-cookbooks/postgresql/issues/302
+  cookbook 'postgresql', '= 3.4.16'
+end

--- a/test/fixtures/cookbooks/confluence_test/README.md
+++ b/test/fixtures/cookbooks/confluence_test/README.md
@@ -1,0 +1,1 @@
+This is a test cookbook

--- a/test/fixtures/cookbooks/confluence_test/metadata.rb
+++ b/test/fixtures/cookbooks/confluence_test/metadata.rb
@@ -1,0 +1,4 @@
+name 'confluence_test'
+version '0.0.1'
+
+depends 'confluence'

--- a/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
@@ -1,0 +1,14 @@
+node.set['confluence']['database']['type'] = 'mysql'
+
+if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 13.10
+  node.set['confluence']['database']['version'] = '5.5'
+else
+  node.set['confluence']['database']['version'] = '5.6'
+end
+
+node.set['mysql']['server_root_password'] = 'iloverandompasswordsbutthiswilldo'
+
+include_recipe 'confluence'
+
+# required for 'infrataster' gem build (integration tests)
+package 'zlib-devel' if node['platform_family'] == 'rhel'

--- a/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
@@ -1,0 +1,15 @@
+node.set['confluence']['database']['type'] = 'postgresql'
+node.set['postgresql']['version'] = '9.3'
+node.set['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
+
+# For old platform versions PostgreSQL 9.3 is available in PGDG repos only
+if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 13.10
+  node.set['postgresql']['enable_pgdg_apt'] = true
+elsif node['platform'] == 'centos' && node['platform_version'].to_f < 7.0
+  node.set['postgresql']['enable_pgdg_yum'] = true
+end
+
+include_recipe 'confluence'
+
+# required for 'infrataster' gem build (integration tests)
+package %w(zlib-devel gcc make patch) if node['platform_family'] == 'rhel'


### PR DESCRIPTION
- Added fixture cookbook for integration tests
  It allows to simplify .kitchen.yml and install packages required for building `nokogiri` gem (`infrataster`'s dependency)
- Removed "ubuntu-15.04" platform from `.kitchen.yml`.  We don't want to run acceptance tests on non-LTS Ubuntu releases.

cc: @Kasen @patcon 
