### PR TITLE
Fix detection of node FQDN / name

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -37,7 +37,7 @@ module Confluence
     end
 
     def confluence_virtual_host_name
-      node['confluence']['apache2']['virtual_host_name'] || node['fqdn']
+      node['confluence']['apache2']['virtual_host_name'] || node['fqdn'] || node['machinename'] || node['hostname']
     end
 
     def confluence_virtual_host_alias


### PR DESCRIPTION
Fixes GH-88
On some systems node['fqdn'] could be empty, so we have to work it around with `'machinename'` and `'hostname'` attributes.
