### PR TITLE
Add kitchen-sync to allow faster SFTP transport

### DIFF
--- a/.kitchen.digitalocean.yml
+++ b/.kitchen.digitalocean.yml
@@ -4,7 +4,7 @@ driver:
   size: 2gb
 
 transport:
-  name: sftp
+  name: rsync
 
 provisioner:
   attributes:

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ end
 
 group :kitchen_cloud do
   gem 'kitchen-digitalocean'
+  gem 'kitchen-sync'
 end
 
 group :development do


### PR DESCRIPTION
The default transport uses net-ssh, which sends all files every time. SFTP is rsync-like and just sends the changes. the sftp transport is enabled in `.kitchen.digitalocean.yml`, but the dep wasn't added to the Gemfile.

https://github.com/coderanger/kitchen-sync
