### PR TITLE
Disable diff output so travis logs don't get too long.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,8 @@ platforms:
 
 provisioner:
   name: chef_zero
+  client_rb:
+    diff_disabled: true
   attributes:
     java:
       install_flavor: oracle

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :unit do
 end
 
 group :kitchen_common do
-  gem 'test-kitchen', '~> 1.5'
+  gem 'test-kitchen', '~> 1.4.0'
 end
 
 group :kitchen_vagrant do


### PR DESCRIPTION
Tests are failing, but I can't see the end of the run easily :)
