### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -51,6 +51,8 @@ provisioner:
       jdk_version: 8
       oracle:
         accept_oracle_download_terms: true
+  client_rb:
+    diff_disabled: true
 
 suites:
 - name: installer-mysql

--- a/test/integration/helpers/serverspec/Gemfile
+++ b/test/integration/helpers/serverspec/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'infrataster'
+# This is required for successful 'nokogiri' install
+# https://github.com/chef/chef-dk/issues/278#issuecomment-185307218
+ENV['PKG_CONFIG_PATH'] = '/opt/chef/embedded/lib/pkgconfig'
+
+gem 'infrataster', '>= 0.3.2'


### PR DESCRIPTION
- Set `ENV['PKG_CONFIG_PATH'] = '/opt/chef/embedded/lib/pkgconfig'` in busser's Gemfile
  (according to https://github.com/chef/chef-dk/issues/278#issuecomment-185307218)
- Disable Chef Client diff output in Docker-driven CI builds

Closes #97 
