### PR TITLE
Fix apache listen ports attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
-depends 'apache2'
+depends 'apache2', '>= 3.2.0'
 depends 'ark'
 depends 'database'
 depends 'java'

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -16,9 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['confluence']['apache2']['port']] unless node['apache']['listen_ports'].include?(node['confluence']['apache2']['port'])
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['confluence']['apache2']['ssl']['port']] unless node['apache']['listen_ports'].include?(node['confluence']['apache2']['ssl']['port'])
+node.default['apache']['listen'] |= [
+  "*:#{node['confluence']['apache2']['port']}",
+  "*:#{node['confluence']['apache2']['ssl']['port']}"
+]
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'


### PR DESCRIPTION
Fixes #102

In cookbook apache2 v3.2.0 the attribute was changed and renamed:
`node.default['apache']['listen_ports']` -> `node.default['apache']['listen']`

P.s. Similar PR to Stash cookbook: https://github.com/bflad/chef-stash/pull/148
