### PR TITLE
Keep backward compatibility with "apache" cookbook versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
-depends 'apache2', '>= 3.2.0'
+depends 'apache2'
 depends 'ark'
 depends 'database'
 depends 'java'

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -16,10 +16,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-node.default['apache']['listen'] |= [
-  "*:#{node['confluence']['apache2']['port']}",
-  "*:#{node['confluence']['apache2']['ssl']['port']}"
-]
+if node['apache'].attribute?('listen_ports')
+  # Compatibility with cookbook 'apache' < 3.2.0
+  node.default['apache']['listen_ports'] |= [
+    node['confluence']['apache2']['port'],
+    node['confluence']['apache2']['ssl']['port']
+  ]
+else
+  node.default['apache']['listen'] |= [
+    "*:#{node['confluence']['apache2']['port']}",
+    "*:#{node['confluence']['apache2']['ssl']['port']}"
+  ]
+end
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'


### PR DESCRIPTION
This PR allows to get rid of `apache` cookbook version lock.
Is similar to https://github.com/bflad/chef-stash/pull/150.
