### PR TITLE
Fix postgresql database collation and template.

### DIFF
--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -70,7 +70,10 @@ when 'postgresql'
   postgresql_database settings['database']['name'] do
     connection confluence_database_connection
     connection_limit '-1'
+    # See: https://confluence.atlassian.com/display/JIRAKB/Health+Check%3A+Database+Collation
     encoding 'utf8'
+    collation 'C'
+    template 'template0'
     owner settings['database']['user']
     action :create
   end


### PR DESCRIPTION
Hi! Just a fix for #3. Ensure postgresql database created is utf-8, C collation and from template0.

As per https://github.com/afklm/jira/blob/049470293cfc3ab2ed022997c1eb9dbd3530b99c/recipes/database.rb#L62-L71
