### PR TITLE
[Rebased] Allow a database recipe to be no-op for HSQLDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ host | FQDN or IP of database server ("127.0.0.1" automatically installs `['data
 name | Confluence database name | String | confluence
 password | Confluence database user password | String | changeit
 port | Confluence database port | Fixnum | 3306 for MySQL, 5432 for PostgreSQL
-type | Confluence database type - "mysql" or "postgresql" | String | mysql
+type | Confluence database type - "mysql", "postgresql", or "hsqldb" | String | mysql
 user | Confluence database user | String | confluence
 
 ### Confluence JVM Attributes

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -80,6 +80,8 @@ module Confluence
         settings['database']['port'] ||= 3306
       when 'postgresql'
         settings['database']['port'] ||= 5432
+      when 'hsqldb'
+        # No-op. HSQLDB doesn't require any configuration.
       else
         raise "Unsupported database type: #{settings['database']['type']}"
       end

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -78,4 +78,6 @@ when 'postgresql'
     action :create
   end
 
+when 'hsqldb'
+  # No-op. HSQLDB doesn't require any configuration.
 end


### PR DESCRIPTION
This is a rebased version of GH-117, authorship is saved.

This PR just adds a support of `hsqldb` database type as a no-op value.
