### PR TITLE
Use the latest "postgresql" cookbook for integration tests

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,8 +6,4 @@ group :integration do
   cookbook 'apt'
   cookbook 'java'
   cookbook 'confluence_test', path: 'test/fixtures/cookbooks/confluence_test'
-
-  # Lock 'postgresql' version due to the issue of derived attributes
-  # https://github.com/hw-cookbooks/postgresql/issues/302
-  cookbook 'postgresql', '= 3.4.16'
 end

--- a/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
@@ -1,12 +1,21 @@
-node.set['confluence']['database']['type'] = 'postgresql'
-node.set['postgresql']['version'] = '9.3'
-node.set['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
+node.normal['confluence']['database']['type'] = 'postgresql'
+node.normal['postgresql']['version'] = '9.3'
+node.normal['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
 
 # For old platform versions PostgreSQL 9.3 is available in PGDG repos only
 if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 13.10
-  node.set['postgresql']['enable_pgdg_apt'] = true
+  node.normal['postgresql']['enable_pgdg_apt'] = true
+  node.normal['postgresql']['client']['packages'] = ['postgresql-client-9.3', 'libpq-dev']
+  node.normal['postgresql']['server']['packages'] = ['postgresql-9.3']
+  node.normal['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.3']
+  node.normal['postgresql']['dir'] = '/etc/postgresql/9.3/main'
+  node.normal['postgresql']['server']['service_name'] = 'postgresql'
 elsif node['platform'] == 'centos' && node['platform_version'].to_f < 7.0
-  node.set['postgresql']['enable_pgdg_yum'] = true
+  node.normal['postgresql']['enable_pgdg_yum'] = true
+  node.normal['postgresql']['client']['packages'] = ['postgresql93', 'postgresql93-devel']
+  node.normal['postgresql']['server']['packages'] = ['postgresql93-server']
+  node.normal['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
+  node.normal['postgresql']['server']['service_name'] = 'postgresql-9.3'
 end
 
 include_recipe 'confluence'


### PR DESCRIPTION
We have to define addition attributes in the fixture cookbook to get Travis CI builds passed on RHEL/CentOS 6.

Verified with `postgresql` cookbook v5.1.0