### PR TITLE
Various fixes for Ubuntu and systemd

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -82,6 +82,7 @@ module Confluence
         settings['database']['port'] ||= 5432
       when 'hsqldb'
         # No-op. HSQLDB doesn't require any configuration.
+        Chef::Log.warn('HSQLDB should not be used in production.')
       else
         raise "Unsupported database type: #{settings['database']['type']}"
       end

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -23,7 +23,7 @@ settings = merge_confluence_settings
 directory File.join(node['confluence']['install_path'], 'conf') do
   owner node['confluence']['user']
   group 'root'
-  mode 00755
+  mode '0755'
   action :create
 end
 
@@ -48,7 +48,7 @@ if node['init_package'] == 'systemd'
     source 'confluence.systemd.erb'
     owner 'root'
     group 'root'
-    mode 00755
+    mode '0755'
     action :create
     notifies :run, 'execute[systemctl-daemon-reload]', :immediately
     notifies :restart, 'service[confluence]', :delayed
@@ -58,7 +58,7 @@ else
     source 'confluence.init.erb'
     owner 'root'
     group 'root'
-    mode 00755
+    mode '0755'
     action :create
     notifies :restart, 'service[confluence]', :delayed
   end

--- a/recipes/crowd_sso.rb
+++ b/recipes/crowd_sso.rb
@@ -4,7 +4,7 @@ template "#{node['confluence']['install_path']}/confluence/WEB-INF/classes/crowd
   source 'crowd.properties.erb'
   owner node['confluence']['user']
   group node['confluence']['user']
-  mode 00644
+  mode '0644'
   action :create
   variables(
     app_name: settings['crowd_sso']['app_name'],

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -80,4 +80,5 @@ when 'postgresql'
 
 when 'hsqldb'
   # No-op. HSQLDB doesn't require any configuration.
+  Chef::Log.warn('HSQLDB should not be used in production')
 end

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -42,4 +42,24 @@ if confluence_version != node['confluence']['version']
     cwd Chef::Config[:file_cache_path]
     command "./atlassian-confluence-#{node['confluence']['version']}.bin -q -varfile atlassian-confluence-response.varfile"
   end
+  
+  # Nasty workaround for intial post-install restart by systemd
+  ruby_block 'Replace exit 1 as workaround for systemd' do
+  block do
+    file_name = "#{node['confluence']['install_path']}/bin/catalina.sh"
+    text = File.read(file_name)
+
+    new_contents = text.gsub('remove the PID file and try again:"
+            ps -f -p $PID
+            exit 1
+          else', 'remove the PID file and try again:"
+            ps -f -p $PID
+            exit 0
+          else')
+
+    File.open(file_name, "w") {|file| file.puts new_contents }
+  end
+  action :run
+end
+
 end

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -20,7 +20,7 @@
 directory File.dirname(node['confluence']['home_path']) do
   owner 'root'
   group 'root'
-  mode 00755
+  mode '0755'
   action :create
   recursive true
 end
@@ -51,7 +51,7 @@ end
   directory File.join(node['confluence']['install_path'], dir) do
     owner node['confluence']['user']
     group 'root'
-    mode 00700
+    mode '0700'
     action :create
   end
 end

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -3,7 +3,7 @@
 # Local modifications will be overwritten by Chef.
 #
 rmiPort$Long=8000
-app.install.service$Boolean=true
+app.install.service$Boolean=false
 existingInstallationDir=<%= node['confluence']['install_path'] %>
 sys.confirmedUpdateInstallationString=<%= @update ? "true" : "false" %>
 sys.languageId=en


### PR DESCRIPTION
WIP - Work In Progress, please don't merge until requested.

**Don't let the installer generate a service** - The installer generates a bogus service file causing systemd to bork. Since we already generate service files for init.d as well as the systemd unit, we don't need the installer to do this.

 **Workaround intial post-install restart issue** - Workaround for catalina.sh script. This script assumes an unrecoverable error and does an "exit 1" if the Confluence process is already running when a start is requested. When using systemd, the unit "fails" to start causing the initial Chef run to fail too.

Note: I realize this particular workaround is not nice, but after exploring several avenues, it seems the most appropriate one until we find the magic bullet. (I don't consider allowing the ExecStart of the unit to fail a suitable fix)