### PR TITLE
Add support of Confluence 6.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ install_path | location to install Confluence | String | /opt/atlassian/confluen
 install_type | Confluence install type - "installer", "standalone" | String | installer
 url | URL for Confluence install | String | auto-detected by library method
 user | user running Confluence | String | confluence
-version | Confluence version to install | String | 5.10.3
+version | Confluence version to install | String | 6.0.2
 
 **Notice:** If `['confluence']['install_type']` is set to `installer`, then the installer will try to upgrade your Confluence instance located in `['confluence']['install_path']` (if it exists) to the `['confluence']['version']`.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['confluence']['home_path']      = '/var/atlassian/application-data/confl
 default['confluence']['install_path']   = '/opt/atlassian/confluence'
 default['confluence']['install_type']   = 'installer'
 default['confluence']['user']           = 'confluence'
-default['confluence']['version']        = '5.10.3'
+default['confluence']['version']        = '6.0.2'
 
 # Defaults are automatically selected from version via helper functions
 default['confluence']['url']            = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -295,6 +295,10 @@ module Confluence
           'x64' => 'aff42d8bcc61ce7358109fe774f8b46c6713f37c362779639bb64326ac126260',
           'tar' => '444d9aa26d459ab41e42852799ffcb0ad04d1fe7471b52f8275f240860014e95',
         },
+        '6.0.2' => {
+          'x64' => '81aa5b4f47e575e7564c0a798b7345820ae405a3b967fc04c8af61f34034da00',
+          'tar' => '7d0632ed2d6db6681bbf0aab8b42c455d6caed8676d4470f90da52efac12500d',
+        },
       }
     end
   end


### PR DESCRIPTION
- Add support of Confluence 6.0.2
- Change the default version to 6.0.2