### PR TITLE
Fix initial service start after installing Confluence with .bin installer

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -35,14 +35,6 @@ platforms:
     intermediate_instructions:
       - RUN yum -y install openssl lsof which systemd-sysv initscripts wget net-tools sudo
 
-- name: ubuntu-12.04
-  driver:
-    image: ubuntu-upstart:12.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install openssl apt-transport-https lsb-release procps net-tools sudo -y
-
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -51,6 +51,14 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install openssl apt-transport-https lsb-release procps net-tools sudo -y
 
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install openssl apt-transport-https lsb-release procps net-tools sudo -y
+
 suites:
 - name: installer-mysql
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,13 +20,6 @@ platforms:
     box: bento/centos-7.1
     image: centos-7-0-x64
 
-- name: ubuntu-12.04
-  run_list:
-    - recipe[apt]
-  driver:
-    box: bento/ubuntu-12.04
-    image: ubuntu-12-04-x64
-
 - name: ubuntu-14.04
   run_list:
     - recipe[apt]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,6 +34,13 @@ platforms:
     box: bento/ubuntu-14.04
     image: ubuntu-14-04-x64
 
+- name: ubuntu-16.04
+  run_list:
+    - recipe[apt]
+  driver:
+    box: bento/ubuntu-16.04
+    image: ubuntu-16-04-x64
+
 provisioner:
   name: chef_zero
   attributes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ services: docker
 
 env:
   matrix:
-  - INSTANCE=installer-mysql-centos-6
-  - INSTANCE=installer-mysql-ubuntu-1204
-  - INSTANCE=installer-postgresql-ubuntu-1204
+  - INSTANCE=installer-mysql-centos-7
+  - INSTANCE=installer-mysql-ubuntu-1404
+  - INSTANCE=installer-postgresql-ubuntu-1604
   - INSTANCE=standalone-mysql-ubuntu-1404
   - INSTANCE=standalone-postgresql-centos-6
-  - INSTANCE=standalone-postgresql-ubuntu-1404
+  - INSTANCE=standalone-postgresql-ubuntu-1604
 
 # Don't `bundle install`
 install: echo "skip bundle install"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installs/Configures an instance of [Atlassian Confluence](https://www.atlassian.
 ### Platforms
 
 * RHEL/CentOS 6, 7
-* Ubuntu 12.04, 14.04
+* Ubuntu 14.04, 16.04
 
 ### Cookbooks
 

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -42,4 +42,13 @@ if confluence_version != node['confluence']['version']
     cwd Chef::Config[:file_cache_path]
     command "./atlassian-confluence-#{node['confluence']['version']}.bin -q -varfile atlassian-confluence-response.varfile"
   end
+
+  # Installer always starts Confluence by `start-confluence.sh`, which could
+  # collide with a service provider (init.d/systemd). We should stop it and then
+  # start as a system service.
+  execute 'Stop Confluence' do
+    command "#{node['confluence']['install_path']}/bin/stop-confluence.sh"
+    ignore_failure true
+    notifies :restart, 'service[confluence]'
+  end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -5,13 +5,17 @@ describe 'confluence::default' do
     ChefSpec::SoloRunner.new do |node|
       node.set['confluence']['install_path'] = '/opt/atlassian/confluence'
       node.set['confluence']['home_path'] = '/var/atlassian/application-data/confluence'
+      node.set['confluence']['version'] = '5.7.1'
       node.set['mysql']['server_root_password'] = 'foo'
+      node.automatic['kernel']['machine'] = 'x86_64'
     end.converge(described_recipe)
   end
 
   before do
     stub_command('/usr/sbin/apache2 -t').and_return(true)
   end
+
+  include_examples 'linux_installer'
 
   it 'renders server.xml' do
     path = '/opt/atlassian/confluence/conf/server.xml'

--- a/spec/linux_standalone_spec.rb
+++ b/spec/linux_standalone_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe 'confluence::linux_standalone' do
-  let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'support/linux_installer'
 
 RSpec.configure do |config|
   config.file_cache_path = '/var/cache/chef'
   config.log_level = :error
   config.platform = 'ubuntu'
-  config.version = '12.04'
+  config.version = '16.04'
 end

--- a/spec/support/linux_installer.rb
+++ b/spec/support/linux_installer.rb
@@ -1,14 +1,4 @@
-require 'spec_helper'
-
-describe 'confluence::linux_installer' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new do |node|
-      node.set['confluence']['version'] = '5.7.1'
-      node.set['confluence']['install_path'] = '/opt/atlassian/confluence'
-      node.automatic['kernel']['machine'] = 'x86_64'
-    end.converge(described_recipe)
-  end
-
+shared_examples 'linux_installer' do
   context 'When Confluence is not installed' do
     before do
       allow_any_instance_of(Chef::Recipe).to receive(:confluence_version).and_return(nil)

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -3,7 +3,7 @@
 # Local modifications will be overwritten by Chef.
 #
 rmiPort$Long=8000
-app.install.service$Boolean=true
+app.install.service$Boolean=false
 existingInstallationDir=<%= node['confluence']['install_path'] %>
 sys.confirmedUpdateInstallationString=<%= @update ? "true" : "false" %>
 sys.languageId=en

--- a/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
@@ -1,11 +1,5 @@
 node.set['confluence']['database']['type'] = 'mysql'
-
-node.set['confluence']['database']['version'] = \
-  if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 13.10
-    '5.5'
-  else
-    '5.6'
-  end
+node.set['confluence']['database']['version'] = '5.6'
 
 node.set['mysql']['server_root_password'] = 'iloverandompasswordsbutthiswilldo'
 

--- a/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
@@ -2,20 +2,20 @@ node.normal['confluence']['database']['type'] = 'postgresql'
 node.normal['postgresql']['version'] = '9.3'
 node.normal['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
 
-# For old platform versions PostgreSQL 9.3 is available in PGDG repos only
-if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 13.10
+if node['platform'] == 'ubuntu'
   node.normal['postgresql']['enable_pgdg_apt'] = true
   node.normal['postgresql']['client']['packages'] = ['postgresql-client-9.3', 'libpq-dev']
   node.normal['postgresql']['server']['packages'] = ['postgresql-9.3']
   node.normal['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.3']
   node.normal['postgresql']['dir'] = '/etc/postgresql/9.3/main'
   node.normal['postgresql']['server']['service_name'] = 'postgresql'
-elsif node['platform'] == 'centos' && node['platform_version'].to_f < 7.0
+elsif node['platform'] == 'centos'
   node.normal['postgresql']['enable_pgdg_yum'] = true
   node.normal['postgresql']['client']['packages'] = ['postgresql93', 'postgresql93-devel']
   node.normal['postgresql']['server']['packages'] = ['postgresql93-server']
   node.normal['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
   node.normal['postgresql']['server']['service_name'] = 'postgresql-9.3'
+  node.normal['postgresql']['setup_script'] = 'postgresql93-setup'
 end
 
 include_recipe 'confluence'


### PR DESCRIPTION
- .kitchen.yml: Add "ubuntu-16.04" 
- test: Remove Ubuntu 12.04 from tests
- test: Use pgdg for all platform versions
- spec: Move "linux_installer" to a separate file as shared examples
- installer: Stop Confluence right after the installer execution

Installer always starts Confluence by `start-confluence.sh`, which could collide with a service provider (init.d/systemd). We should stop it and then start as a system service.