### PR TITLE
Add Synchrony websocket support for Confluence 6.0

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -7,3 +7,7 @@ group :integration do
   cookbook 'java'
   cookbook 'confluence_test', path: 'test/fixtures/cookbooks/confluence_test'
 end
+
+# Temporary lock. Remove it when this PR is merged and released:
+# https://github.com/sous-chefs/postgresql/pull/396
+cookbook 'postgresql', '= 5.1.0'

--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -42,11 +42,15 @@ echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
 
 # Set the JVM arguments used to start Confluence. For a description of the options, see
 # http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
-CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCTimeStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
 CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
 CATALINA_OPTS="-Datlassian.plugins.enable.wait=300 ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xms<%= node['confluence']['jvm']['minimum_memory'] %> -Xmx<%= node['confluence']['jvm']['maximum_memory'] %> -XX:+UseG1GC ${CATALINA_OPTS}"
+<% if node['confluence']['version'].to_f >= 6.0 -%>
+CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
+<% end -%>
 export CATALINA_OPTS
 
 <% if node['confluence']['jvm']['java_opts'] != '' -%>

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -46,8 +46,35 @@
 		Require all granted
 	<% end -%>
 	</Proxy>
+
+	<% if node['confluence']['version'].to_f >= 6.0 -%>
+	ProxyPass /synchrony http://localhost:8091/synchrony
+
+	<Location /synchrony>
+		<% if node['apache']['version'].to_f < 2.4 -%>
+		Order Deny,Allow
+		Allow from all
+		<% else -%>
+		Require all granted
+		<% end -%>
+		RewriteEngine on
+		RewriteCond %{HTTP:UPGRADE} ^WebSocket$ [NC]
+		RewriteCond %{HTTP:CONNECTION} Upgrade$ [NC]
+		RewriteRule .* ws://%{HTTP_HOST}:8091%{REQUEST_URI} [P]
+	</Location>
+	<% end -%>
+
 	ProxyPass        / http://localhost:<%= node['confluence']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
 	ProxyPassReverse / http://localhost:<%= node['confluence']['tomcat']['port'] %>/
+
+	<Location />
+	<% if node['apache']['version'].to_f < 2.4 -%>
+		Order Deny,Allow
+		Allow from all
+	<% else -%>
+		Require all granted
+	<% end -%>
+	</Location>
 
 	SSLEngine on
 	SSLCertificateFile <%= node['confluence']['apache2']['ssl']['certificate_file'] %>


### PR DESCRIPTION
Confluence 6.0 introduces a new feature - Collaborative Editing. It is implemented by a new
component - Synchrony, which requires a reverse proxy to be configured in a special way.

CATALINA_OPTS in `setenv.sh` are also updated according to the latest state in Confluence v6.0.2.
Backward compatibility is saved: tested with both of Confluence 5.10.8 and 6.0.2.

Closes #130 