### PR TITLE
Feature added autotune

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ maximum_permgen | JVM maximum PermGen memory | String | 256m
 java_opts | additional JAVA_OPTS to be passed to Confluence JVM during startup | String | ""
 bundled_jre | prefer JRE bundled with linux installer | Boolean | true
 
+### Confluence Autotune Attributes
+
+These attributes are under the `node['confluence']['autotune']` namespace. Autotune automatically determines appropriate settings for certain
+attributes. This feature is inspired by the `autotune` recipe in the https://github.com/afklm/jira cookbook. This
+initial version only supports JVM min and max memory size tuning.
+
+There are several tuning types that can be set:
+
+* 'mixed' - JIRA and DB run on the same system
+* 'dedicated' - JIRA has the system all to itself
+* 'shared' - JIRA shares the system with the DB and other applications
+
+Total available memory is auto discovered using Ohai but can be overridden by setting your own value in kB.
+
+Attribute    | Description                                                           | Type    | Default
+-------------|-----------------------------------------------------------------------|---------|------------
+enabled      | Whether or not to autotune settings.                                  | Boolean | false
+type         | Type of tuning to apply. One of 'mixed', 'dedicated' and 'shared'.    | String  | mixed
+total_memory | Total system memory to use for autotune calculations.                 | String  | Ohai value
+
+
+
 ### Confluence Tomcat Attributes
 
 These attributes are under the `node['confluence']['tomcat']` namespace.

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ initial version only supports JVM min and max memory size tuning.
 
 There are several tuning types that can be set:
 
-* 'mixed' - JIRA and DB run on the same system
-* 'dedicated' - JIRA has the system all to itself
-* 'shared' - JIRA shares the system with the DB and other applications
+* 'mixed' - Confluence and DB run on the same system
+* 'dedicated' - Confluence has the system all to itself
+* 'shared' - Confluence shares the system with the DB and other applications
 
 Total available memory is auto discovered using Ohai but can be overridden by setting your own value in kB.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,16 +60,12 @@ default['confluence']['database']['password'] = 'changeit'
 default['confluence']['database']['type'] = 'mysql'
 default['confluence']['database']['user'] = 'confluence'
 
-# Types include: 'mixed', 'dedicated', 'shared'
-# 'mixed'     - Confluence and DB run on the same system
-# 'dedicated' - Confluence has the system all to itself
-# 'shared'    - Confluence shares the system with the DB and other applications
 default['confluence']['autotune']['enabled'] = false
 default['confluence']['autotune']['type']    = 'mixed'
 
 # If you don't want total system memory to be automatically discovered through
 # Ohai, uncomment the following line and set your own value in kB.
-# default['jira']['autotune']['total_memory'] = '1048576kB' # 1024m
+# default['confluence']['autotune']['total_memory'] = '1048576kB' # 1024m
 
 default['confluence']['jvm']['bundled_jre'] = true
 default['confluence']['jvm']['minimum_memory'] = '256m'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,7 +60,6 @@ default['confluence']['database']['password'] = 'changeit'
 default['confluence']['database']['type'] = 'mysql'
 default['confluence']['database']['user'] = 'confluence'
 
-
 # Types include: 'mixed', 'dedicated', 'shared'
 # 'mixed'     - Confluence and DB run on the same system
 # 'dedicated' - Confluence has the system all to itself

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,18 @@ default['confluence']['database']['password'] = 'changeit'
 default['confluence']['database']['type'] = 'mysql'
 default['confluence']['database']['user'] = 'confluence'
 
+
+# Types include: 'mixed', 'dedicated', 'shared'
+# 'mixed'     - Confluence and DB run on the same system
+# 'dedicated' - Confluence has the system all to itself
+# 'shared'    - Confluence shares the system with the DB and other applications
+default['confluence']['autotune']['enabled'] = false
+default['confluence']['autotune']['type']    = 'mixed'
+
+# If you don't want total system memory to be automatically discovered through
+# Ohai, uncomment the following line and set your own value in kB.
+# default['jira']['autotune']['total_memory'] = '1048576kB' # 1024m
+
 default['confluence']['jvm']['bundled_jre'] = true
 default['confluence']['jvm']['minimum_memory'] = '256m'
 default['confluence']['jvm']['maximum_memory'] = '512m'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -277,6 +277,61 @@ module Confluence
         },
       }
     end
+
+    def binround(value)
+      # Keep a multiplier which grows through powers of 1
+      multiplier = 1
+
+      # Truncate value to 4 most significant bits
+      while value >= 16
+        value = (value / 2).floor
+        multiplier *= 2
+      end
+
+      # Factor any remaining powers of 2 into the multiplier
+      while value == 2 * (value / 2).floor
+        value = (value / 2).floor
+        multiplier *= 2
+      end
+
+      # Factor enough powers of 2 back into the value to
+      # leave the multiplier as a power of 1024 that can
+      # be represented as units of "g", "m" or "k".
+
+      # Disabled g and k calculations for now because we prefer easy comparison between values
+
+      # if multiplier >= 1024 * 1024 * 1024
+      #   while multiplier > 1024 * 1024 * 1024
+      #     value *= 2
+      #     multiplier = (multiplier / 2).floor
+      #   end
+      #   multiplier = 1
+      #   units = 'g'
+
+      # elsif multiplier >= 1024 * 1024
+      if multiplier >= 1024 * 1024
+        while multiplier > 1024 * 1024
+          value *= 2
+          multiplier = (multiplier / 2).floor
+        end
+        multiplier = 1
+        units = 'm'
+
+        # elsif multiplier >= 1024
+        #   while multiplier > 1024
+        #     value *= 2
+        #     multiplier = (multiplier / 2).floor
+        #   end
+        #   multiplier = 1
+        #   units = 'k'
+
+      else
+        units = ''
+      end
+
+      # Now we can return a nice human readable string.
+      "#{multiplier * value}#{units}"
+    end # end normalize def
   end
 end
 

--- a/recipes/autotune.rb
+++ b/recipes/autotune.rb
@@ -5,7 +5,6 @@
 #
 # See https://github.com/afklm/jira/
 
-
 tune_type = 'mixed'
 
 # Check if type is selected and if its a valid type
@@ -14,10 +13,10 @@ if node['confluence'].attribute?('autotune') && node['confluence']['autotune'].a
 
   unless %w(mixed dedicated shared).include?(tune_type)
     Chef::Log.fatal([
-                        "Bad value (#{tune_type}) for node['confluence']['autotune']['type'] attribute.",
-                        'Valid values are one of mixed, dedicated, shared.'
-                    ].join(' '))
-    fail
+      "Bad value (#{tune_type}) for node['confluence']['autotune']['type'] attribute.",
+      'Valid values are one of mixed, dedicated, shared.',
+    ].join(' '))
+    raise
   end
 end
 
@@ -28,9 +27,9 @@ if node['confluence'].attribute?('autotune') && node['confluence']['autotune'].a
   total_memory = node['confluence']['autotune']['total_memory']
   if total_memory.match(/\A\d*kB\Z/).nil?
     Chef::Application.fatal!([
-                                 "Bad value (#{total_memory}) for node['confluence']['autotune']['total_memory'] attribute.",
-                                 'Valid values are non-zero integers followed by kB (e.g., 49416564kB).'
-                             ].join(' '))
+      "Bad value (#{total_memory}) for node['confluence']['autotune']['total_memory'] attribute.",
+      'Valid values are non-zero integers followed by kB (e.g., 49416564kB).',
+    ].join(' '))
   end
 end
 
@@ -38,19 +37,19 @@ end
 mem = total_memory.split('kB')[0].to_i / 1024 # in MB
 
 maximum_memory =
-    { 'mixed' => (mem / 100) * 70,
-      'dedicated' => (mem / 100) * 80,
-      'shared' => (mem / 100) * 50
-    }.fetch(tune_type)
+  { 'mixed' => (mem / 100) * 70,
+    'dedicated' => (mem / 100) * 80,
+    'shared' => (mem / 100) * 50,
+  }.fetch(tune_type)
 
 node.default['confluence']['jvm']['maximum_memory'] = binround(maximum_memory * 1024 * 1024)
 Chef::Log.warn("Autotuning CONFLUENCE max memory to #{node['confluence']['jvm']['maximum_memory']}.")
 
 minimum_memory =
-    { 'mixed' => (maximum_memory / 100) * 80,
-      'dedicated' => maximum_memory,
-      'shared' => (maximum_memory / 100) * 50
-    }.fetch(tune_type)
+  { 'mixed' => (maximum_memory / 100) * 80,
+    'dedicated' => maximum_memory,
+    'shared' => (maximum_memory / 100) * 50,
+  }.fetch(tune_type)
 
 node.default['confluence']['jvm']['minimum_memory'] = binround(minimum_memory * 1024 * 1024)
 Chef::Log.warn("Autotuning CONFLUENCE min memory to #{node['confluence']['jvm']['minimum_memory']}.")
@@ -58,5 +57,5 @@ Chef::Log.warn("Autotuning CONFLUENCE min memory to #{node['confluence']['jvm'][
 # Lets make sure we have at least 512 MB
 if minimum_memory < 512
   Chef::Log.fatal('Autotune reports less than 512 MB available for CONFLUENCE, please make at least 512 MB memory available.')
-  fail
+  raise
 end

--- a/recipes/autotune.rb
+++ b/recipes/autotune.rb
@@ -1,0 +1,62 @@
+# This recipe tries to autotune various settings, most notable JVM heap size.
+#
+# The idea and portions of the code were taken from the afklm/jira
+# cookbook and its autotune recipe.
+#
+# See https://github.com/afklm/jira/
+
+
+tune_type = 'mixed'
+
+# Check if type is selected and if its a valid type
+if node['confluence'].attribute?('autotune') && node['confluence']['autotune'].attribute?('type')
+  tune_type = node['confluence']['autotune']['type']
+
+  unless %w(mixed dedicated shared).include?(tune_type)
+    Chef::Log.fatal([
+                        "Bad value (#{tune_type}) for node['confluence']['autotune']['type'] attribute.",
+                        'Valid values are one of mixed, dedicated, shared.'
+                    ].join(' '))
+    fail
+  end
+end
+
+# Parse out total_memory option, or use value detected by Ohai.
+total_memory = node['memory']['total']
+
+if node['confluence'].attribute?('autotune') && node['confluence']['autotune'].attribute?('total_memory')
+  total_memory = node['confluence']['autotune']['total_memory']
+  if total_memory.match(/\A\d*kB\Z/).nil?
+    Chef::Application.fatal!([
+                                 "Bad value (#{total_memory}) for node['confluence']['autotune']['total_memory'] attribute.",
+                                 'Valid values are non-zero integers followed by kB (e.g., 49416564kB).'
+                             ].join(' '))
+  end
+end
+
+# Ohai reports node[:memory][:total] in kB, as in "921756kB"
+mem = total_memory.split('kB')[0].to_i / 1024 # in MB
+
+maximum_memory =
+    { 'mixed' => (mem / 100) * 70,
+      'dedicated' => (mem / 100) * 80,
+      'shared' => (mem / 100) * 50
+    }.fetch(tune_type)
+
+node.default['confluence']['jvm']['maximum_memory'] = binround(maximum_memory * 1024 * 1024)
+Chef::Log.warn("Autotuning CONFLUENCE max memory to #{node['confluence']['jvm']['maximum_memory']}.")
+
+minimum_memory =
+    { 'mixed' => (maximum_memory / 100) * 80,
+      'dedicated' => maximum_memory,
+      'shared' => (maximum_memory / 100) * 50
+    }.fetch(tune_type)
+
+node.default['confluence']['jvm']['minimum_memory'] = binround(minimum_memory * 1024 * 1024)
+Chef::Log.warn("Autotuning CONFLUENCE min memory to #{node['confluence']['jvm']['minimum_memory']}.")
+
+# Lets make sure we have at least 512 MB
+if minimum_memory < 512
+  Chef::Log.fatal('Autotune reports less than 512 MB available for CONFLUENCE, please make at least 512 MB memory available.')
+  fail
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@ settings = merge_confluence_settings
 include_recipe 'confluence::database' if settings['database']['host'] == '127.0.0.1'
 include_recipe "confluence::linux_#{node['confluence']['install_type']}"
 include_recipe 'confluence::configuration'
-include_recipe 'confluence::autotune' if settings['autotune']['enabled'] == true
+include_recipe 'confluence::autotune' if settings['autotune']['enabled']
 include_recipe 'confluence::tomcat_configuration'
 include_recipe 'confluence::apache2'
 include_recipe 'confluence::crowd_sso' if settings['crowd_sso']['enabled']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ settings = merge_confluence_settings
 include_recipe 'confluence::database' if settings['database']['host'] == '127.0.0.1'
 include_recipe "confluence::linux_#{node['confluence']['install_type']}"
 include_recipe 'confluence::configuration'
+include_recipe 'confluence::autotune' if settings['autotune']['enabled'] == true
 include_recipe 'confluence::tomcat_configuration'
 include_recipe 'confluence::apache2'
 include_recipe 'confluence::crowd_sso' if settings['crowd_sso']['enabled']

--- a/spec/autotune_spec.rb
+++ b/spec/autotune_spec.rb
@@ -3,12 +3,11 @@
 require 'spec_helper'
 
 describe 'confluence::autotune' do
-
   context 'When autotune type is dedicated' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['confluence']['autotune']['enabled'] = true
-        node.set['confluence']['autotune']['type']='dedicated'
+        node.set['confluence']['autotune']['type'] = 'dedicated'
         node.automatic['memory']['total'] = '8011076kB'
       end.converge(described_recipe)
     end
@@ -17,16 +16,15 @@ describe 'confluence::autotune' do
       expect(chef_run.node['confluence']['jvm']['maximum_memory']).to eq('6144m')
     end
     it 'the jvm min memory' do
-    expect(chef_run.node['confluence']['jvm']['minimum_memory']).to eq('6144m')
+      expect(chef_run.node['confluence']['jvm']['minimum_memory']).to eq('6144m')
     end
   end
-
 
   context 'When autotune type is shared' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['confluence']['autotune']['enabled'] = true
-        node.set['confluence']['autotune']['type']='shared'
+        node.set['confluence']['autotune']['type'] = 'shared'
         node.automatic['memory']['total'] = '8011076kB'
       end.converge(described_recipe)
     end
@@ -43,7 +41,7 @@ describe 'confluence::autotune' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['confluence']['autotune']['enabled'] = true
-        node.set['confluence']['autotune']['type']='mixed'
+        node.set['confluence']['autotune']['type'] = 'mixed'
         node.automatic['memory']['total'] = '8011076kB'
       end.converge(described_recipe)
     end
@@ -55,6 +53,4 @@ describe 'confluence::autotune' do
       expect(chef_run.node['confluence']['jvm']['minimum_memory']).to eq('4096m')
     end
   end
-
-
 end

--- a/spec/autotune_spec.rb
+++ b/spec/autotune_spec.rb
@@ -1,0 +1,60 @@
+
+
+require 'spec_helper'
+
+describe 'confluence::autotune' do
+
+  context 'When autotune type is dedicated' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['confluence']['autotune']['enabled'] = true
+        node.set['confluence']['autotune']['type']='dedicated'
+        node.automatic['memory']['total'] = '8011076kB'
+      end.converge(described_recipe)
+    end
+
+    it 'the jvm max memory' do
+      expect(chef_run.node['confluence']['jvm']['maximum_memory']).to eq('6144m')
+    end
+    it 'the jvm min memory' do
+    expect(chef_run.node['confluence']['jvm']['minimum_memory']).to eq('6144m')
+    end
+  end
+
+
+  context 'When autotune type is shared' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['confluence']['autotune']['enabled'] = true
+        node.set['confluence']['autotune']['type']='shared'
+        node.automatic['memory']['total'] = '8011076kB'
+      end.converge(described_recipe)
+    end
+
+    it 'the jvm max memory' do
+      expect(chef_run.node['confluence']['jvm']['maximum_memory']).to eq('3840m')
+    end
+    it 'the jvm min memory' do
+      expect(chef_run.node['confluence']['jvm']['minimum_memory']).to eq('1920m')
+    end
+  end
+
+  context 'When autotune type is mixed' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['confluence']['autotune']['enabled'] = true
+        node.set['confluence']['autotune']['type']='mixed'
+        node.automatic['memory']['total'] = '8011076kB'
+      end.converge(described_recipe)
+    end
+
+    it 'the jvm max memory' do
+      expect(chef_run.node['confluence']['jvm']['maximum_memory']).to eq('5120m')
+    end
+    it 'the jvm min memory' do
+      expect(chef_run.node['confluence']['jvm']['minimum_memory']).to eq('4096m')
+    end
+  end
+
+
+end


### PR DESCRIPTION
I am using this cookbook for the last few days and setting up jvm memory can be tricky if you don't have much Java experience.
As this was based on the [Jira cookbook](https://github.com/afklm/jira), I have ported the autotune recipe to the confluence cookbook.
Even the default setting for autotune is false. When used, it will make confluence run better and utilize better the server memory.
