### PR TITLE
Update setenv.sh.erb update JRE_HOME condition

### DIFF
--- a/templates/default/setenv.sh.erb
+++ b/templates/default/setenv.sh.erb
@@ -58,7 +58,7 @@ JAVA_OPTS="<%= node['confluence']['jvm']['java_opts']%>"
 export JAVA_OPTS
 <% end -%>
 
-<% if node['confluence']['install_type'] == 'installer' && node['confluence']['jvm']['bundled_jre'] -%>
+<% if node['confluence']['install_type'] == 'installer' && node['confluence']['jvm']['bundled_jre'] = true -%>
 JRE_HOME="<%= node['confluence']['install_path'] %>/jre/"; export JRE_HOME
 <% else -%>
 JRE_HOME="<%= node['java']['java_home'] %>/jre/"; export JRE_HOME


### PR DESCRIPTION
By updating the AND condition to "bundled_jre = true" (which is the default attribute value), it allows the condition to evaluate to false by setting attribute "bundled_jre = false". This allows the java cookbook's java_home attribute to be set, if it has been overridden. 

Without the "= true" condition, the IF condition can't be bypassed to the ELSE condition, if desired, when using the installer.

I know the official confluence documentation states that the JRE is supported platform. As a former Atlassian support engineer, we used to recommend using the JDK over JRE. Whether the reasons for that recommendation are still valid, I can't say. I think this change is worth while, since it would only change behavior if one wants to override the default attribute value. 