### PR TITLE
Add recipe for configuring firewall.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -67,3 +67,12 @@ suites:
   attributes:
     confluence:
       install_type: standalone
+
+- name: standalone-postgresql-firewall
+  run_list:
+  - recipe[java]
+  - recipe[confluence_test::postgresql]
+  - recipe[confluence::firewall]
+  attributes:
+    confluence:
+      install_type: standalone

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ port | Tomcat HTTP port | Fixnum | 8090
 * `recipe[confluence::linux_standalone]` Installs/configures Confluence via Linux standalone archive"
 * `recipe[confluence::tomcat_configuration]` Configures Confluence's built-in Tomcat
 * `recipe[confluence::crowd_sso]` Configures user authentication with Crowd single sign-on
+* `recipe[confluence::firewall]` Configures the firewall to open specific ports
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,3 +79,5 @@ default['confluence']['crowd_sso']['enabled'] = false
 default['confluence']['crowd_sso']['app_name'] = nil
 default['confluence']['crowd_sso']['app_password'] = nil
 default['confluence']['crowd_sso']['crowd_base_url'] = 'http://crowd.example.com:8095/crowd'
+
+default['confluence']['firewall']['ports'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ recipe 'confluence::linux_installer', 'Installs/configures Confluence via Linux 
 recipe 'confluence::linux_standalone', 'Installs/configures Confluence via Linux standalone archive'
 recipe 'confluence::tomcat_configuration', "Configures Confluence's built-in Tomcat"
 recipe 'confluence::crowd_sso', 'Configures user authentication with Crowd single sign-on'
+recipe 'confluence::firewall', 'Configures the firewall to open specific ports'
 
 supports 'amazon'
 supports 'centos'
@@ -26,6 +27,7 @@ supports 'ubuntu'
 depends 'apache2'
 depends 'ark'
 depends 'database'
+depends 'firewall'
 depends 'java'
 depends 'mysql', '< 8.0'
 depends 'mysql_connector'

--- a/recipes/firewall.rb
+++ b/recipes/firewall.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook Name:: confluence
+# Recipe:: apache2
+#
+# Copyright 2017, Jens Grassel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'firewall::default'
+
+ports =
+  if node['confluence']['firewall']['ports'].nil? || node['confluence']['firewall']['ports'].empty?
+    "#{node['confluence']['apache2']['port']},#{node['confluence']['apache2']['ssl']['port']},#{node['confluence']['tomcat']['port']}".split(',').map(&:to_i)
+  else
+    node['confluence']['firewall']['ports'].split(',').map(&:to_i)
+  end
+
+firewall_rule "open ports #{ports}" do
+  port ports
+  protocol :tcp
+  command :allow
+end

--- a/test/integration/standalone-postgresql-firewall/serverspec/standalone-postgresql-firewall_spec.rb
+++ b/test/integration/standalone-postgresql-firewall/serverspec/standalone-postgresql-firewall_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'Java' do
+  describe command('java -version 2>&1') do
+    its(:exit_status) { should eq 0 }
+  end
+end
+
+describe 'Postgresql' do
+  describe port(5432) do
+    it { should be_listening }
+  end
+end
+
+describe 'Confluence' do
+  it_behaves_like 'confluence behind the apache proxy'
+end


### PR DESCRIPTION
* add dependency for firewall cookbook
* add empty default attributes for firewall ports
* use apache and tomcat ports if no ports are specified
* add recipe firewall to open ports

This is rather quick work, therefore I'm thankful for suggestions and advice.