### PR TITLE
Add support for 6.0.5 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ install_path | location to install Confluence | String | /opt/atlassian/confluen
 install_type | Confluence install type - "installer", "standalone" | String | installer
 url | URL for Confluence install | String | auto-detected by library method
 user | user running Confluence | String | confluence
-version | Confluence version to install | String | 6.0.3
+version | Confluence version to install | String | 6.0.5
 
 **Notice:** If `['confluence']['install_type']` is set to `installer`, then the installer will try to upgrade your Confluence instance located in `['confluence']['install_path']` (if it exists) to the `['confluence']['version']`.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['confluence']['home_path'] = '/var/atlassian/application-data/confluence
 default['confluence']['install_path'] = '/opt/atlassian/confluence'
 default['confluence']['install_type'] = 'installer'
 default['confluence']['user'] = 'confluence'
-default['confluence']['version'] = '6.0.4'
+default['confluence']['version'] = '6.0.5'
 default['confluence']['backup_when_update'] = true
 
 # Defaults are automatically selected from version via helper functions

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -279,6 +279,10 @@ module Confluence
           'x64' => '7bc9001af3e75712f1ea0bcf4f3a9261186f95d0d50a5bc1e8d236acf2c5a88d',
           'tar' => '5cb6751ad10e34ca708b7930f54982a81d303ddc1d821fac8928a28a7cb974f1',
         },
+        '6.0.5' => {
+          'x64' => '1ff4402a6dd03e01f80a31260ff2e0292f0a2679e5b955f005584366f6a14097',
+          'tar' => 'd8fddc80a4f3b4a5c8fd6d6d87b1c473044275f13acdb489b6fa30c576bdf07d',
+        },
       }
     end
 


### PR DESCRIPTION
Generated SHA256 for Linux .bin and .tar.gz and bumped versions in README and default attributes.