### PR TITLE
Add block for 6.8.2 to helper library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Confluence Cookbook Changelog
+## 2.5.1 (October 24, 2018)
+IMPROVEMENTS:
+- Added hash values to support for Confluence version `6.8.2`.
 
 ## 2.5.0 (May 10, 2018)
 - Changed cookbook ownership to Sous Chefs Community. Hopefully cookbook will come back to life.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Confluence Cookbook Changelog
-## 2.5.1 (October 24, 2018)
+## 2.5.0 (October 24, 2018)
 IMPROVEMENTS:
 - Added hash values to support for Confluence version `6.8.2`.
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -320,8 +320,8 @@ module Confluence
           'tar' => '2099d20b6b7b678f3be87972c656fad3cd65ae8517f5de56cafb454d3062f038',
         },
         '6.8.2' => {
-          'x64' => '5a1baccc4fe0701beac020d3e4095d5a7b6b6a038766d4da373bf4d127020312',
-          'tar' => 'cb2bbd9298ac0c31054d8e64ddb045e896e3fbe11d8ab48482d436647567f195',
+          'x64' => 'cb2bbd9298ac0c31054d8e64ddb045e896e3fbe11d8ab48482d436647567f195',
+          'tar' => '5a1baccc4fe0701beac020d3e4095d5a7b6b6a038766d4da373bf4d127020312',
         }
       }
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -319,6 +319,10 @@ module Confluence
           'x64' => 'e0adb605f75028c34461c46582aa14c1acf89bb15213df437c51fbf15f701091',
           'tar' => '2099d20b6b7b678f3be87972c656fad3cd65ae8517f5de56cafb454d3062f038',
         },
+        '6.8.2' => {
+          'x64' => '5a1baccc4fe0701beac020d3e4095d5a7b6b6a038766d4da373bf4d127020312',
+          'tar' => 'cb2bbd9298ac0c31054d8e64ddb045e896e3fbe11d8ab48482d436647567f195',
+        }
       }
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'anuriq@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures Atlassian Confluence'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.5.1'
+version '2.5.0'
 
 issues_url 'https://github.com/sous-chefs/confluence/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/sous-chefs/confluence' if respond_to?(:source_url)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'anuriq@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures Atlassian Confluence'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.5.0'
+version '2.5.1'
 
 issues_url 'https://github.com/sous-chefs/confluence/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/sous-chefs/confluence' if respond_to?(:source_url)


### PR DESCRIPTION
## Description
Add a block for 6.8.2 to helper library -- includes SHA-256 checksums

### Issues Resolved
Addition of new confluence version (6.8.2)

### Check List
- [X] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
