### PR TITLE
Use new style comment headers and remove some node.set usage

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,9 +1,9 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Attributes:: confluence
 #
-# Copyright 2013, Brian Flad
-# Copyright 2017, Parallels International GmbH
+# Copyright:: 2013, Brian Flad
+# Copyright:: 2017, Parallels International GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Library:: helpers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: apache2
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: configuration
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: database
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: default
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/linux_installer.rb
+++ b/recipes/linux_installer.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: linux_installer
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: linux_standalone
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/tomcat_configuration.rb
+++ b/recipes/tomcat_configuration.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: confluence
+# Cookbook:: confluence
 # Recipe:: tomcat_configuration
 #
-# Copyright 2013, Brian Flad
+# Copyright:: 2013, Brian Flad
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
@@ -1,7 +1,7 @@
-node.set['confluence']['database']['type'] = 'mysql'
-node.set['confluence']['database']['version'] = '5.6'
+node.normal['confluence']['database']['type'] = 'mysql'
+node.normal['confluence']['database']['version'] = '5.6'
 
-node.set['mysql']['server_root_password'] = 'iloverandompasswordsbutthiswilldo'
+node.normal['mysql']['server_root_password'] = 'iloverandompasswordsbutthiswilldo'
 
 include_recipe 'confluence'
 

--- a/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
@@ -11,7 +11,7 @@ if node['platform'] == 'ubuntu'
   node.normal['postgresql']['server']['service_name'] = 'postgresql'
 elsif node['platform'] == 'centos'
   node.normal['postgresql']['enable_pgdg_yum'] = true
-  node.normal['postgresql']['client']['packages'] = ['postgresql93', 'postgresql93-devel']
+  node.normal['postgresql']['client']['packages'] = %w(postgresql93 postgresql93-devel)
   node.normal['postgresql']['server']['packages'] = ['postgresql93-server']
   node.normal['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
   node.normal['postgresql']['server']['service_name'] = 'postgresql-9.3'


### PR DESCRIPTION
Node.set has been removed in modern Chef Infra Client. This PR replaces the usage.

Signed-off-by: Tim Smith <tsmith@chef.io>