### PR TITLE
confluence: run `cookstyle -a .`

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,19 +3,11 @@ maintainer 'Azat Khadiev'
 maintainer_email 'anuriq@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures Atlassian Confluence'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+
 version '2.5.1'
 
-issues_url 'https://github.com/sous-chefs/confluence/issues' if respond_to?(:issues_url)
-source_url 'https://github.com/sous-chefs/confluence' if respond_to?(:source_url)
-
-recipe 'confluence', 'Installs/configures Atlassian Confluence'
-recipe 'confluence::apache2', 'Installs/configures Apache 2 as proxy (ports 80/443)'
-recipe 'confluence::database', 'Installs/configures MySQL/PostgreSQL server, database, and user for Confluence'
-recipe 'confluence::linux_installer', 'Installs/configures Confluence via Linux installer'
-recipe 'confluence::linux_standalone', 'Installs/configures Confluence via Linux standalone archive'
-recipe 'confluence::tomcat_configuration', "Configures Confluence's built-in Tomcat"
-recipe 'confluence::crowd_sso', 'Configures user authentication with Crowd single sign-on'
+issues_url 'https://github.com/sous-chefs/confluence/issues'
+source_url 'https://github.com/sous-chefs/confluence'
 
 supports 'amazon'
 supports 'centos'
@@ -32,4 +24,4 @@ depends 'mysql_connector'
 depends 'mysql2_chef_gem', '< 2.0.0'
 depends 'postgresql'
 
-chef_version '< 13.0.0' if respond_to?(:chef_version)
+chef_version '< 13.0.0'

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -29,7 +29,7 @@ user node['confluence']['user'] do
   comment 'Confluence Service Account'
   home node['confluence']['home_path']
   shell '/bin/bash'
-  supports manage_home: true
+  manage_home true
   system true
   action :create
 end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -15,7 +15,7 @@ describe 'confluence::database' do
 
   context 'When data bag does not exit' do
     before do
-      chef_run.node.set['confluence']['database']['type'] = 'mysql'
+      chef_run.node.default['confluence']['database']['type'] = 'mysql'
     end
 
     let(:connection) do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -36,8 +36,8 @@ describe 'confluence::default' do
 
   context 'for "installer" installation type' do
     it 'uses JRE managed by "java" cookbook when bundled_jre attribute is false' do
-      chef_run.node.set['java']['java_home'] = '/usr/lib/jvm/java'
-      chef_run.node.set['confluence']['jvm']['bundled_jre'] = false
+      chef_run.node.default['java']['java_home'] = '/usr/lib/jvm/java'
+      chef_run.node.default['confluence']['jvm']['bundled_jre'] = false
 
       expect(chef_run).to render_file('/opt/atlassian/confluence/bin/setenv.sh')
         .with_content { |content|
@@ -48,8 +48,8 @@ describe 'confluence::default' do
 
   context 'for "standalone" installation type' do
     it 'uses JRE managed by "java" cookbook' do
-      chef_run.node.set['java']['java_home'] = '/usr/lib/jvm/java'
-      chef_run.node.set['confluence']['install_type'] = 'standalone'
+      chef_run.node.default['java']['java_home'] = '/usr/lib/jvm/java'
+      chef_run.node.default['confluence']['install_type'] = 'standalone'
 
       expect(chef_run).to render_file('/opt/atlassian/confluence/bin/setenv.sh')
         .with_content { |content|

--- a/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/mysql.rb
@@ -1,9 +1,9 @@
-node.normal['confluence']['database']['type'] = 'mysql'
-node.normal['confluence']['database']['version'] = '5.6'
+node.default['confluence']['database']['type'] = 'mysql'
+node.default['confluence']['database']['version'] = '5.6'
 
-node.normal['mysql']['server_root_password'] = 'iloverandompasswordsbutthiswilldo'
+node.default['mysql']['server_root_password'] = 'iloverandompasswordsbutthiswilldo'
 
 include_recipe 'confluence'
 
 # required for 'infrataster' gem build (integration tests)
-package 'zlib-devel' if node['platform_family'] == 'rhel'
+package 'zlib-devel' if platform_family?('rhel')

--- a/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
@@ -1,24 +1,24 @@
-node.normal['confluence']['database']['type'] = 'postgresql'
-node.normal['postgresql']['version'] = '9.3'
-node.normal['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
+node.default['confluence']['database']['type'] = 'postgresql'
+node.default['postgresql']['version'] = '9.3'
+node.default['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
 
-if node['platform'] == 'ubuntu'
-  node.normal['postgresql']['enable_pgdg_apt'] = true
-  node.normal['postgresql']['client']['packages'] = ['postgresql-client-9.3', 'libpq-dev']
-  node.normal['postgresql']['server']['packages'] = ['postgresql-9.3']
-  node.normal['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.3']
-  node.normal['postgresql']['dir'] = '/etc/postgresql/9.3/main'
-  node.normal['postgresql']['server']['service_name'] = 'postgresql'
-elsif node['platform'] == 'centos'
-  node.normal['postgresql']['enable_pgdg_yum'] = true
-  node.normal['postgresql']['client']['packages'] = %w(postgresql93 postgresql93-devel)
-  node.normal['postgresql']['server']['packages'] = ['postgresql93-server']
-  node.normal['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
-  node.normal['postgresql']['server']['service_name'] = 'postgresql-9.3'
-  node.normal['postgresql']['setup_script'] = 'postgresql93-setup'
+if platform_family?('rhel')
+  node.default['postgresql']['enable_pgdg_apt'] = true
+  node.default['postgresql']['client']['packages'] = ['postgresql-client-9.3', 'libpq-dev']
+  node.default['postgresql']['server']['packages'] = ['postgresql-9.3']
+  node.default['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.3']
+  node.default['postgresql']['dir'] = '/etc/postgresql/9.3/main'
+  node.default['postgresql']['server']['service_name'] = 'postgresql'
+elsif platform_family?('rhel')
+  node.default['postgresql']['enable_pgdg_yum'] = true
+  node.default['postgresql']['client']['packages'] = %w(postgresql93 postgresql93-devel)
+  node.default['postgresql']['server']['packages'] = ['postgresql93-server']
+  node.default['postgresql']['contrib']['packages'] = ['postgresql93-contrib']
+  node.default['postgresql']['server']['service_name'] = 'postgresql-9.3'
+  node.default['postgresql']['setup_script'] = 'postgresql93-setup'
 end
 
 include_recipe 'confluence'
 
 # required for 'infrataster' gem build (integration tests)
-package %w(zlib-devel gcc make patch) if node['platform_family'] == 'rhel'
+package %w(zlib-devel gcc make patch) if platform_family?('rhel')

--- a/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
+++ b/test/fixtures/cookbooks/confluence_test/recipes/postgresql.rb
@@ -2,14 +2,14 @@ node.default['confluence']['database']['type'] = 'postgresql'
 node.default['postgresql']['version'] = '9.3'
 node.default['postgresql']['password']['postgres'] = 'iloverandompasswordsbutthiswilldo'
 
-if platform_family?('rhel')
+if platform_family?('ubuntu')
   node.default['postgresql']['enable_pgdg_apt'] = true
   node.default['postgresql']['client']['packages'] = ['postgresql-client-9.3', 'libpq-dev']
   node.default['postgresql']['server']['packages'] = ['postgresql-9.3']
   node.default['postgresql']['contrib']['packages'] = ['postgresql-contrib-9.3']
   node.default['postgresql']['dir'] = '/etc/postgresql/9.3/main'
   node.default['postgresql']['server']['service_name'] = 'postgresql'
-elsif platform_family?('rhel')
+elsif platform_family?('centos')
   node.default['postgresql']['enable_pgdg_yum'] = true
   node.default['postgresql']['client']['packages'] = %w(postgresql93 postgresql93-devel)
   node.default['postgresql']['server']['packages'] = ['postgresql93-server']


### PR DESCRIPTION
## Description

`cookstyle -a .` and manual fixes for cookstyle improvements.

Ran from latest chef/chefdk docker image.
```
root@1b30b6bf5af8:/home# chef --version
ChefDK version: 4.4.27
Chef Infra Client version: 15.3.14
Chef InSpec version: 4.16.0
Test Kitchen version: 2.3.3
Foodcritic version: 16.1.1
Cookstyle version: 5.6.2
```
### Issues Resolved

https://github.com/sous-chefs/confluence/issues/187

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
