### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb                   # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs/Configures Atlassian Confluence using custom resources
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Distribution Method
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Installs/Configures Atlassian Confluence using custom resources
 
 Atlassian Confluence is distributed as a vendor binary — not through OS package managers (apt, yum, dnf, zypper). This cookbook downloads the standalone tarball directly from Atlassian's download site.
 
-- **Standalone tarball** (`atlassian-confluence-<version>.tar.gz`): Platform-independent Java application archive
-- **Binary installer** (`atlassian-confluence-<version>-x64.bin`): 64-bit Linux only
+* **Standalone tarball** (`atlassian-confluence-<version>.tar.gz`): Platform-independent Java application archive
+* **Binary installer** (`atlassian-confluence-<version>-x64.bin`): 64-bit Linux only
 
 This cookbook uses the **standalone tarball** method.
 
@@ -36,40 +36,40 @@ No official Atlassian zypper repository exists. Confluence is not available via 
 
 ## Architecture Limitations
 
-- The standalone tarball is a Java application and is architecture-independent
-- The binary installer is available for **x86_64 (64-bit) only**
-- arm64 (aarch64) is supported via the standalone tarball since it is pure Java
+* The standalone tarball is a Java application and is architecture-independent
+* The binary installer is available for **x86_64 (64-bit) only**
+* arm64 (aarch64) is supported via the standalone tarball since it is pure Java
 
 ## Operating System Support
 
 Atlassian officially supports "Linux (most distributions)" without specifying particular distributions. The cookbook supports:
 
-- AlmaLinux 8, 9
-- Amazon Linux 2023
-- CentOS Stream 9
-- Debian 12
-- Fedora (latest)
-- Oracle Linux 8, 9
-- Red Hat Enterprise Linux 8, 9
-- Rocky Linux 8, 9
-- Ubuntu 22.04, 24.04
+* AlmaLinux 8, 9
+* Amazon Linux 2023
+* CentOS Stream 9
+* Debian 12
+* Fedora (latest)
+* Oracle Linux 8, 9
+* Red Hat Enterprise Linux 8, 9
+* Rocky Linux 8, 9
+* Ubuntu 22.04, 24.04
 
 ### Unsupported
 
-- Alpine Linux 3.5 and earlier (known Atlassian incompatibility)
-- Windows Nano
-- macOS / OSX (evaluation only per Atlassian)
+* Alpine Linux 3.5 and earlier (known Atlassian incompatibility)
+* Windows Nano
+* macOS / OSX (evaluation only per Atlassian)
 
 ## Java Requirements
 
-- Confluence requires **Java 21** (Oracle JDK or Eclipse Temurin)
-- The standalone tarball does **not** bundle a JRE — Java must be installed separately
-- The binary installer bundles Temurin Java 21
+* Confluence requires **Java 21** (Oracle JDK or Eclipse Temurin)
+* The standalone tarball does **not** bundle a JRE — Java must be installed separately
+* The binary installer bundles Temurin Java 21
 
 This cookbook does **not** manage Java installation. Use a separate cookbook such as [java](https://github.com/sous-chefs/java).
 
 ## Known Issues
 
-- Confluence will not work with MariaDB (use MySQL 8.4 instead)
-- Confluence will not work with Percona Server
-- This cookbook does not manage database or reverse proxy configuration
+* Confluence will not work with MariaDB (use MySQL 8.4 instead)
+* Confluence will not work with Percona Server
+* This cookbook does not manage database or reverse proxy configuration

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -10,5 +10,5 @@ cookbook 'test', path: './test/cookbooks/test'
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
 
-  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+  named_run_list recipe_name.to_sym, 'recipe[test::' + recipe_name + ']'
 end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'confluence'
+
+run_list 'recipe[test::default]'
+
+cookbook 'confluence', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -21,9 +21,13 @@ verifier:
 
 suites:
   - name: default
+    provisioner:
+      named_run_list: default
     run_list:
       - recipe[test::default]
 
   - name: standalone
+    provisioner:
+      named_run_list: standalone
     run_list:
       - recipe[test::standalone]

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -29,26 +29,28 @@ property :service_name, String,
 
 action :create do
   systemd_unit "#{new_resource.service_name}.service" do
-    content({
-      'Unit' => {
-        'Description' => 'Atlassian Confluence',
-        'After' => 'network.target',
-      },
-      'Service' => {
-        'Type' => 'forking',
-        'User' => new_resource.user,
-        'Group' => new_resource.group,
-        'Environment' => "CONFLUENCE_HOME=#{new_resource.home_path}",
-        'PIDFile' => "#{new_resource.install_path}/work/catalina.pid",
-        'ExecStart' => "#{new_resource.install_path}/bin/start-confluence.sh",
-        'ExecStop' => "#{new_resource.install_path}/bin/stop-confluence.sh",
-        'TimeoutStartSec' => 300,
-        'TimeoutStopSec' => 60,
-      },
-      'Install' => {
-        'WantedBy' => 'multi-user.target',
-      },
-    })
+    content(
+      {
+        'Unit' => {
+          'Description' => 'Atlassian Confluence',
+          'After' => 'network.target',
+        },
+        'Service' => {
+          'Type' => 'forking',
+          'User' => new_resource.user,
+          'Group' => new_resource.group,
+          'Environment' => "CONFLUENCE_HOME=#{new_resource.home_path}",
+          'PIDFile' => "#{new_resource.install_path}/work/catalina.pid",
+          'ExecStart' => "#{new_resource.install_path}/bin/start-confluence.sh",
+          'ExecStop' => "#{new_resource.install_path}/bin/stop-confluence.sh",
+          'TimeoutStartSec' => 300,
+          'TimeoutStopSec' => 60,
+        },
+        'Install' => {
+          'WantedBy' => 'multi-user.target',
+        },
+      }
+    )
     action :create
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -5,8 +5,3 @@ maintainer: Sous Chefs
 license: Apache-2.0
 summary: Integration tests for the default Confluence installation
 version: 1.0.0
-supports:
-  - platform-family: debian
-  - platform-family: rhel
-  - platform-family: fedora
-  - platform-family: amazon

--- a/test/integration/standalone/inspec.yml
+++ b/test/integration/standalone/inspec.yml
@@ -5,8 +5,3 @@ maintainer: Sous Chefs
 license: Apache-2.0
 summary: Integration tests for standalone Confluence installation with reverse proxy config
 version: 1.0.0
-supports:
-  - platform-family: debian
-  - platform-family: rhel
-  - platform-family: fedora
-  - platform-family: amazon


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list